### PR TITLE
Remove trailing blanks in f90-ts-comment-region-with-prefix

### DIFF
--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -4577,52 +4577,78 @@ Otherwise mark the region spanned by the node itself (like enlarge-region)."
 ;;;-----------------------------------------------------------------------------
 ;;; Comment region using some prefix
 
-;; The following code are adapted from `f90.el', which is part of GNU Emacs.
+
+(defun f90-ts--comment-region-ins-del (beg end prefix prefix-trimmed re-uncomment)
+  "Insert or delete PREFIX at each line between BEG and END."
+  (goto-char beg)
+  (beginning-of-line)
+  (cl-loop
+   do (cond
+       ((looking-at re-uncomment)
+        (delete-region (match-beginning 1) (match-end 1)))
+       ((looking-at-p "[ \t]*$")
+        ;; avoid trailing blanks on empty lines
+        (insert prefix-trimmed))
+       (t
+        (insert prefix)))
+   while (and (zerop (forward-line 1))
+              (< (point) end))))
+
+(defun f90-ts--comment-region-adjust (beg end re-adjust)
+  "Adjust indentation between BEG and END.
+Use regexp RE-ADJUST to identify inserted comment prefix.
+This keeps commented code at the same column as before (if comment
+prefix allows it, which is usually/often the case with column-0
+and context type prefixes)."
+  (goto-char end)
+  ;; if end marker is at end of line, skip that line
+  (if (bolp)
+      (forward-line -1)
+    (beginning-of-line))
+  (cl-loop
+   do (when (looking-at re-adjust)
+        (let* ((cap-group-before (if f90-ts-comment-prefix-keep-indent 1 2))
+               (len-before (length (match-string cap-group-before)))
+               (after (match-string 3))
+               (len-after (min len-before (length after))))
+          (when (> len-after 0)
+            (delete-region (match-beginning 3)
+                           (+ (match-beginning 3) len-after)))))
+   while (and (> (point) beg)
+              (zerop (forward-line -1)))))
+
+;; The following code was originally adapted from `f90.el' (part of GNU Emacs).
 (defun f90-ts-comment-region-with-prefix (beg-region end-region prefix)
   "Comment/uncomment every line in the region using comment PREFIX.
 Region is given by BEG-REGION and END-REGION.
+
 Insert comment prefix at every line in the region, taking special comment
 rules for indentation of comment prefix into account.
-If the prefix is already present, then remove it and uncomment the line."
+
+If the prefix is already present, then remove it and uncomment the line.
+
+Note that prefixes are allowed to have trailing blanks.  These are inserted
+as well.  However, for uncommenting, the trimmed prefix is used."
   (let* ((prefix-re (regexp-quote prefix))
-         (re-uncomment (concat "\\s-*\\(?1:" prefix-re "\\)"))
-         (re-adjust    (concat "\\(?1:\\(?2:\\s-*\\)" prefix-re "\\)\\(?3:\\s-*\\)")))
+         (re-adjust    (concat "\\(?1:\\(?2:\\s-*\\)" prefix-re "\\)\\(?3:\\s-*\\)"))
+         (prefix-trimmed (string-trim-right prefix))
+         (prefix-trimmed-re (regexp-quote prefix-trimmed))
+         (re-uncomment (concat "\\s-*\\(?1:" prefix-trimmed-re "\\)")))
     (let ((beg (copy-marker beg-region))
           (end (copy-marker end-region t)))
       (unwind-protect
           (progn
-            ;; pass 1: insert or remove prefix at column 0 for each line
-            ;; in the region
-            (goto-char beg)
-            (beginning-of-line)
-            (cl-loop
-             do (if (looking-at re-uncomment)
-                    (delete-region (match-beginning 1) (match-end 1))
-                  (insert prefix))
-             while (and (zerop (forward-line 1))
-                        (< (point) end)))
-            ;; pass 2: re-indent the whole region at once
+            ;; pass 1 (insert/delete comment prefix)
+            (f90-ts--comment-region-ins-del beg
+                                            end
+                                            prefix
+                                            prefix-trimmed
+                                            re-uncomment)
+            ;; pass 2
             (treesit-indent-region beg end)
-            ;; pass 3 (backwards): for each commented line, strip the blanks
-            ;; that indent added before the prefix from after the prefix, this
-            ;; preserve original indentation within comment if possible
-            (goto-char end)
-            ;; if end marker is at end of line, this line is not processed
-            (if (bolp)
-                (forward-line -1)
-              (beginning-of-line))
-            (cl-loop
-             do (when (looking-at re-adjust)
-                  (let* ((cap-group-before (if f90-ts-comment-prefix-keep-indent 1 2))
-                         (len-before (length (match-string cap-group-before)))
-                         (after (match-string 3))
-                         (len-after (min len-before
-                                         (length after))))
-                    (when (> len-after 0)
-                      (delete-region (match-beginning 3)
-                                     (+ (match-beginning 3) len-after)))))
-             while (and (> (point) beg)
-                        (zerop (forward-line -1))))
+            ;; pass 3 (adjust indentation within commented part)
+            (f90-ts--comment-region-adjust beg end re-adjust)
+
             (goto-char end))
         (set-marker beg nil)
         (set-marker end nil)))))

--- a/test/resources/comment_region.erts
+++ b/test/resources/comment_region.erts
@@ -301,7 +301,6 @@ subroutine sub_un_custom_1()
 end subroutine sub_un_custom_1
 =-=-=
 
-
 Code:
   (lambda ()
     (f90-ts-mode)
@@ -398,4 +397,64 @@ subroutine sub_custom_3()
 !!$  end if
 |end subroutine sub_custom_3
 
+=-=-=
+
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (f90-ts-comment-region-custom 29 156 "! "))
+
+Name: comment region trailing blank 1
+=-=
+subroutine sub_trailing_1()
+     if (x > 1) then
+
+          call to_be_commented()
+|
+          ! comment: do i=1,10
+          ! end do comment
+     end if
+
+end subroutine sub_trailing_1
+=-=
+subroutine sub_trailing_1()
+     ! if (x > 1) then
+     !
+     !    call to_be_commented()
+     !
+     comment: do i=1,10
+     end do comment
+     ! end if
+     !
+|end subroutine sub_trailing_1
+=-=-=
+
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (f90-ts-comment-region-custom 29 166 "!!$    "))
+
+Name: comment region trailing blank 2
+=-=
+subroutine sub_trailing_2()
+     if (x > 1) then
+
+          call to_be_commented()
+|
+          !!$    comment: do i=1,10
+          !!$    end do comment
+     end if
+
+end subroutine sub_trailing_2
+=-=
+subroutine sub_trailing_2()
+!!$    if (x > 1) then
+!!$
+!!$       call to_be_commented()
+!!$
+     comment: do i=1,10
+     end do comment
+!!$    end if
+!!$
+|end subroutine sub_trailing_2
 =-=-=


### PR DESCRIPTION
Remove trailing blanks in f90-ts-comment-region-with-prefix if prefix is inserted into an empty line. A prefix is allowed to have trailing blanks, which is useful if the line is non-empty and there should be a single or more blanks between comment prefix and commented part.
