### PR TITLE
Preserve relative indentation in comment region operation

### DIFF
--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -4577,45 +4577,69 @@ Otherwise mark the region spanned by the node itself (like enlarge-region)."
 ;;;-----------------------------------------------------------------------------
 ;;; Comment region using some prefix
 
-
-(defun f90-ts--comment-region-ins-del (beg end prefix prefix-trimmed re-uncomment)
+(defun f90-ts--comment-region-ins-del (beg end prefix)
   "Insert or delete PREFIX at each line between BEG and END."
-  (goto-char beg)
-  (beginning-of-line)
-  (cl-loop
-   do (cond
-       ((looking-at re-uncomment)
-        (delete-region (match-beginning 1) (match-end 1)))
-       ((looking-at-p "[ \t]*$")
-        ;; avoid trailing blanks on empty lines
-        (insert prefix-trimmed))
-       (t
-        (insert prefix)))
-   while (and (zerop (forward-line 1))
-              (< (point) end))))
+  (let* ((prefix-trimmed (string-trim-right prefix))
+         (prefix-trimmed-re (regexp-quote prefix-trimmed))
+         (uncomment-re (concat "\\s-*\\(?1:" prefix-trimmed-re "\\)")))
+    (goto-char beg)
+    (beginning-of-line)
+    (cl-loop
+     do (cond
+         ((looking-at uncomment-re)
+          (delete-region (match-beginning 1) (match-end 1)))
+         ((looking-at-p "[ \t]*$")
+          ;; avoid trailing blanks on empty lines
+          (insert prefix-trimmed))
+         (t
+          (insert prefix)))
+     while (and (zerop (forward-line 1))
+                (< (point) end)))))
 
-(defun f90-ts--comment-region-adjust (beg end re-adjust)
-  "Adjust indentation between BEG and END.
-Use regexp RE-ADJUST to identify inserted comment prefix.
-This keeps commented code at the same column as before (if comment
-prefix allows it, which is usually/often the case with column-0
-and context type prefixes)."
-  (goto-char end)
-  ;; if end marker is at end of line, skip that line
-  (if (bolp)
-      (forward-line -1)
-    (beginning-of-line))
-  (cl-loop
-   do (when (looking-at re-adjust)
-        (let* ((cap-group-before (if f90-ts-comment-prefix-keep-indent 1 2))
-               (len-before (length (match-string cap-group-before)))
-               (after (match-string 3))
-               (len-after (min len-before (length after))))
-          (when (> len-after 0)
-            (delete-region (match-beginning 3)
-                           (+ (match-beginning 3) len-after)))))
-   while (and (> (point) beg)
-              (zerop (forward-line -1)))))
+
+(defun f90-ts--comment-region-adjust (beg end prefix)
+  "Adjust indentation of code between BEG and END commented by PREFIX.
+After pasting PREFIX and indenting the commented region, the commented code
+is adjusted to preserve original indentation as far as possible.  This also
+depends on option `f90-ts-comment-prefix-keep-indent'.  This also takes into
+account, that different types of prefixes might be indented differently,
+depending on `f90-ts-special-comment-rules'."
+    (goto-char end)
+    ;; if end marker is at end of line, skip that line
+    (if (bolp)
+        (forward-line -1)
+      (beginning-of-line))
+
+    (let* ((prefix-re (regexp-quote prefix))
+           (adjust-re (concat "\\(?1:\\(?2:\\s-*\\)" prefix-re "\\)\\(?3:\\s-*\\)"))
+           (min-len-after
+            ;; determine maximal number of blanks we can delete in each line safely,
+            ;; using the same number for each line preserves relative indentation
+            (cl-loop
+             do (beginning-of-line)
+             if (looking-at adjust-re)
+             minimize (let* ((cap-group-before (if f90-ts-comment-prefix-keep-indent 1 2))
+                             (len-before (length (match-string cap-group-before)))
+                             (after (match-string 3)))
+                        (min len-before (length after)))
+             while (and (> (point) beg)
+                        (zerop (forward-line -1))))))
+
+      ;; delete blanks uniformly in a second pass, but only
+      ;; if blanks can be removed at all
+      (when (and min-len-after
+                 (> min-len-after 0))
+        (goto-char end)
+        (if (bolp)
+            (forward-line -1)
+          (beginning-of-line))
+        (cl-loop
+         do (when (looking-at adjust-re)
+              (delete-region (match-beginning 3)
+                             (+ (match-beginning 3) min-len-after)))
+         while (and (> (point) beg)
+                    (zerop (forward-line -1)))))))
+
 
 ;; The following code was originally adapted from `f90.el' (part of GNU Emacs).
 (defun f90-ts-comment-region-with-prefix (beg-region end-region prefix)
@@ -4629,29 +4653,20 @@ If the prefix is already present, then remove it and uncomment the line.
 
 Note that prefixes are allowed to have trailing blanks.  These are inserted
 as well.  However, for uncommenting, the trimmed prefix is used."
-  (let* ((prefix-re (regexp-quote prefix))
-         (re-adjust    (concat "\\(?1:\\(?2:\\s-*\\)" prefix-re "\\)\\(?3:\\s-*\\)"))
-         (prefix-trimmed (string-trim-right prefix))
-         (prefix-trimmed-re (regexp-quote prefix-trimmed))
-         (re-uncomment (concat "\\s-*\\(?1:" prefix-trimmed-re "\\)")))
-    (let ((beg (copy-marker beg-region))
-          (end (copy-marker end-region t)))
-      (unwind-protect
-          (progn
-            ;; pass 1 (insert/delete comment prefix)
-            (f90-ts--comment-region-ins-del beg
-                                            end
-                                            prefix
-                                            prefix-trimmed
-                                            re-uncomment)
-            ;; pass 2
-            (treesit-indent-region beg end)
-            ;; pass 3 (adjust indentation within commented part)
-            (f90-ts--comment-region-adjust beg end re-adjust)
+  (let ((beg (copy-marker beg-region))
+        (end (copy-marker end-region t)))
+    (unwind-protect
+        (progn
+          ;; pass 1 (insert/delete comment prefix)
+          (f90-ts--comment-region-ins-del beg end prefix)
+          ;; pass 2
+          (treesit-indent-region beg end)
+          ;; pass 3 (adjust indentation within commented part)
+          (f90-ts--comment-region-adjust beg end prefix)
 
-            (goto-char end))
-        (set-marker beg nil)
-        (set-marker end nil)))))
+          (goto-char end))
+      (set-marker beg nil)
+      (set-marker end nil))))
 
 
 (defun f90-ts-comment-region-default (beg-region end-region)
@@ -4675,9 +4690,9 @@ If called interactively, prompt for a prefix from
       (region-beginning))
     (region-end)
     (completing-read "choose comment prefix: "
-                          (append f90-ts-extra-comment-prefixes
-                                  (list f90-ts-comment-region-prefix))
-                          nil t nil nil (car f90-ts-extra-comment-prefixes))))
+                     (append f90-ts-extra-comment-prefixes
+                             (list f90-ts-comment-region-prefix))
+                     nil t nil nil (car f90-ts-extra-comment-prefixes))))
   (f90-ts-comment-region-with-prefix beg-region
                                      end-region
                                      prefix))

--- a/test/resources/comment_region.erts
+++ b/test/resources/comment_region.erts
@@ -3,17 +3,21 @@ Point-Char: |
 Code:
   (lambda ()
     (f90-ts-mode)
-    (f90-ts-comment-region-default 1 77))
+    (f90-ts-comment-region-default 1 115))
 
 Name: comment region all 1
 =-=
 subroutine sub_all_1()
-|     call to_be_commented()
+     if (x > 0) then
+|          call to_be_commented()
+     end if
 end subroutine sub_all_1
 
 =-=
 !!$ subroutine sub_all_1()
-!!$  call to_be_commented()
+!!$      if (x > 0) then
+!!$           call to_be_commented()
+!!$      end if
 !!$ end subroutine sub_all_1
 |
 =-=-=
@@ -21,37 +25,63 @@ end subroutine sub_all_1
 Code:
   (lambda ()
     (f90-ts-mode)
-    (f90-ts-comment-region-default 5 60))
+    (f90-ts-comment-region-default 5 100))
 
 Name: comment region all 2
 =-=
-subroutine sub_2()
-|     call to_be_commented()
-end subroutine sub_2
+subroutine sub_all_2()
+     if (x > 0) then
+|          call to_be_commented()
+     end if
+end subroutine sub_all_2
 
 =-=
-!!$ subroutine sub_2()
-!!$  call to_be_commented()
-!!$ end subrouti|ne sub_2
+!!$ subroutine sub_all_2()
+!!$      if (x > 0) then
+!!$           call to_be_commented()
+!!$      end if
+!!$ end subrou|tine sub_all_2
 
 =-=-=
 
 Code:
   (lambda ()
     (f90-ts-mode)
-    (let ((f90-ts-comment-prefix-keep-indent nil))
-      (f90-ts-comment-region-default 1 77)))
+    (f90-ts-comment-region-default 1 140))
 
 Name: comment region all 3
 =-=
-subroutine sub_all_3()
-|     call to_be_commented()
-end subroutine sub_all_3
+     subroutine sub_all_3()
+          if (x > 0) then
+|               call to_be_commented()
+          end if
+     end subroutine sub_all_3
 
 =-=
-!!$ subroutine sub_all_3()
-!!$      call to_be_commented()
-!!$ end subroutine sub_all_3
+!!$  subroutine sub_all_3()
+!!$       if (x > 0) then
+!!$            call to_be_commented()
+!!$       end if
+!!$  end subroutine sub_all_3
+|
+=-=-=
+
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (let ((f90-ts-comment-prefix-keep-indent nil))
+      (f90-ts-comment-region-default 1 92)))
+
+Name: comment region all 4
+=-=
+     subroutine sub_all_4()
+|          call to_be_commented()
+     end subroutine sub_all_4
+
+=-=
+!!$      subroutine sub_all_4()
+!!$           call to_be_commented()
+!!$      end subroutine sub_all_4
 |
 =-=-=
 
@@ -420,7 +450,7 @@ end subroutine sub_trailing_1
 subroutine sub_trailing_1()
      ! if (x > 1) then
      !
-     !    call to_be_commented()
+     !      call to_be_commented()
      !
      comment: do i=1,10
      end do comment
@@ -450,7 +480,7 @@ end subroutine sub_trailing_2
 subroutine sub_trailing_2()
 !!$    if (x > 1) then
 !!$
-!!$       call to_be_commented()
+!!$         call to_be_commented()
 !!$
      comment: do i=1,10
      end do comment


### PR DESCRIPTION
Preserve relative indentation in a code block commented by comment region.
