### PR TITLE
Fix workflow actions

### DIFF
--- a/.github/workflows/emacs-pr.yml
+++ b/.github/workflows/emacs-pr.yml
@@ -1,7 +1,6 @@
-name: Emacs CI (tree-sitter + checks)
+name: emacs f90-mode standard
 
 on:
-  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -30,37 +29,68 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
+            autoconf \
+            automake \
+            texinfo \
             libjansson-dev \
             libgnutls28-dev \
             libncurses-dev \
-            texinfo \
+            libgccjit-13-dev \
             git \
-            cmake
+            cmake \
+            pkg-config
 
       # -------------------------
       # Build tree-sitter 0.25.x
       # -------------------------
       - name: Build tree-sitter 0.25
         run: |
-          git clone https://github.com/tree-sitter/tree-sitter.git
+          git clone --depth 1 --branch v0.25.10 https://github.com/tree-sitter/tree-sitter.git
           cd tree-sitter
-          git checkout v0.25.10
 
-          make
+          make -j$(nproc)
           make PREFIX=$HOME/local install
 
           echo "LD_LIBRARY_PATH=$HOME/local/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
           echo "LIBRARY_PATH=$HOME/local/lib:$LIBRARY_PATH" >> $GITHUB_ENV
           echo "CPATH=$HOME/local/include:$CPATH" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=$HOME/local/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
 
       # -------------------------
-      # Build Emacs
+      # Build Emacs (linked to TS 0.25)
       # -------------------------
-      - name: Install Emacs
-        uses: purcell/setup-emacs@master
-        with:
-          version: ${{ matrix.emacs-version }}
+      - name: Build Emacs ${{ matrix.emacs-version }}
+        run: |
+          git clone --depth 1 --branch emacs-${{ matrix.emacs-version }} \
+            https://github.com/emacs-mirror/emacs.git
+          cd emacs
 
+          ./autogen.sh
+
+          ./configure \
+            LDFLAGS="-Wl,-rpath,$HOME/local/lib" \
+            CPPFLAGS="-I$HOME/local/include" \
+            --prefix=$HOME/emacs \
+            --with-tree-sitter \
+            --with-gnutls \
+            --without-x \
+            --without-sound \
+            --without-sqlite3 \
+            --without-xml2 \
+            --without-mailutils \
+            --without-pop \
+            --without-native-compilation \
+            --without-compress-install \
+            CFLAGS="-O2"
+
+          make -j$(nproc)
+          make install
+
+          echo "$HOME/emacs/bin" >> $GITHUB_PATH
+
+      # -------------------------
+      # Verify Emacs + linkage
+      # -------------------------
       - name: Verify version
         run: emacs --version
 
@@ -68,63 +98,43 @@ jobs:
         run: |
           EMACS_BIN=$(which emacs)
           echo "Emacs binary: $EMACS_BIN"
-          LDD_OUT=$(ldd "$EMACS_BIN" | grep libtree-sitter)
+
+          LDD_OUT=$(ldd "$EMACS_BIN" | grep libtree-sitter || true)
           echo "tree-sitter linkage: $LDD_OUT"
+
           if ! echo "$LDD_OUT" | grep -q "libtree-sitter.so.0.25"; then
             echo "Error: Emacs is not linked against libtree-sitter.so.0.25"
             exit 1
           fi
-          echo "Emacs is linked against libtree-sitter.so.0.25"
+
+          echo "Emacs is correctly linked against libtree-sitter.so.0.25"
 
       # -------------------------
-      # Build Emacs
-      # -------------------------
-      # - name: Build Emacs ${{ matrix.emacs-version }}
-      #   run: |
-      #     git clone --depth 1 --filter=blob:none https://github.com/emacs-mirror/emacs.git
-      #     cd emacs
-      #     git fetch --depth 1 origin tag emacs-${{ matrix.emacs-version }}
-      #     git checkout emacs-${{ matrix.emacs-version }}
-
-      #     ./autogen.sh
-      #     ./configure \
-      #       LDFLAGS="-Wl,-rpath,$HOME/local/lib" \
-      #       --with-gnutls \
-      #       --with-zlib \
-      #       --without-native-compilation \
-      #       --with-tree-sitter \
-      #       --without-mailutils \
-      #       --without-pop \
-      #       --without-x \
-      #       --without-sound \
-      #       --without-sqlite3 \
-      #       --without-xml2 \
-      #       --without-threads \
-      #       --without-compress-install \
-      #       CFLAGS="-O2"
-      #     make -j$(nproc)
-      #     sudo make install
-
-      # -------------------------
-      # Build Fortran grammar (mscfd/master)
+      # Install tree-sitter CLI
       # -------------------------
       - name: Install tree-sitter CLI
         run: |
           npm install -g tree-sitter-cli@0.25.10
 
+      # -------------------------
+      # Build tree-sitter-fortran
+      # -------------------------
       - name: Build tree-sitter-fortran
         run: |
           git clone --depth 1 --single-branch --branch master \
             https://github.com/mscfd/tree-sitter-fortran.git
           cd tree-sitter-fortran
+
           echo "Grammar commit: $(git rev-parse HEAD)"
 
           tree-sitter generate
 
           cc -fPIC -c src/parser.c
           cc -fPIC -c src/scanner.c 2>/dev/null || true
+
           cc -shared parser.o scanner.o -o libtree-sitter-fortran.so || \
             cc -shared parser.o -o libtree-sitter-fortran.so
+
           mkdir -p ~/.emacs.d/tree-sitter
           cp libtree-sitter-fortran.so ~/.emacs.d/tree-sitter/
 

--- a/.github/workflows/emacs-push.yml
+++ b/.github/workflows/emacs-push.yml
@@ -1,7 +1,7 @@
-name: Emacs CI (tree-sitter + checks)
+name: emacs f90-mode extra
 
 on:
-  push:
+  workflow_dispatch:
 
 jobs:
   check:
@@ -37,37 +37,68 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
+            autoconf \
+            automake \
+            texinfo \
             libjansson-dev \
             libgnutls28-dev \
             libncurses-dev \
-            texinfo \
+            libgccjit-13-dev \
             git \
-            cmake
+            cmake \
+            pkg-config
 
       # -------------------------
       # Build tree-sitter 0.25.x
       # -------------------------
       - name: Build tree-sitter 0.25
         run: |
-          git clone https://github.com/tree-sitter/tree-sitter.git
+          git clone --depth 1 --branch v0.25.10 https://github.com/tree-sitter/tree-sitter.git
           cd tree-sitter
-          git checkout v0.25.10
 
-          make
+          make -j$(nproc)
           make PREFIX=$HOME/local install
 
           echo "LD_LIBRARY_PATH=$HOME/local/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
           echo "LIBRARY_PATH=$HOME/local/lib:$LIBRARY_PATH" >> $GITHUB_ENV
           echo "CPATH=$HOME/local/include:$CPATH" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=$HOME/local/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
 
       # -------------------------
-      # Build Emacs
+      # Build Emacs (linked to TS 0.25)
       # -------------------------
-      - name: Install Emacs
-        uses: purcell/setup-emacs@master
-        with:
-          version: ${{ matrix.emacs-version }}
+      - name: Build Emacs ${{ matrix.emacs-version }}
+        run: |
+          git clone --depth 1 --branch emacs-${{ matrix.emacs-version }} \
+            https://github.com/emacs-mirror/emacs.git
+          cd emacs
 
+          ./autogen.sh
+
+          ./configure \
+            LDFLAGS="-Wl,-rpath,$HOME/local/lib" \
+            CPPFLAGS="-I$HOME/local/include" \
+            --prefix=$HOME/emacs \
+            --with-tree-sitter \
+            --with-gnutls \
+            --without-x \
+            --without-sound \
+            --without-sqlite3 \
+            --without-xml2 \
+            --without-mailutils \
+            --without-pop \
+            --without-native-compilation \
+            --without-compress-install \
+            CFLAGS="-O2"
+
+          make -j$(nproc)
+          make install
+
+          echo "$HOME/emacs/bin" >> $GITHUB_PATH
+
+      # -------------------------
+      # Verify Emacs + linkage
+      # -------------------------
       - name: Verify version
         run: emacs --version
 
@@ -75,63 +106,43 @@ jobs:
         run: |
           EMACS_BIN=$(which emacs)
           echo "Emacs binary: $EMACS_BIN"
-          LDD_OUT=$(ldd "$EMACS_BIN" | grep libtree-sitter)
+
+          LDD_OUT=$(ldd "$EMACS_BIN" | grep libtree-sitter || true)
           echo "tree-sitter linkage: $LDD_OUT"
+
           if ! echo "$LDD_OUT" | grep -q "libtree-sitter.so.0.25"; then
             echo "Error: Emacs is not linked against libtree-sitter.so.0.25"
             exit 1
           fi
-          echo "Emacs is linked against libtree-sitter.so.0.25"
+
+          echo "Emacs is correctly linked against libtree-sitter.so.0.25"
 
       # -------------------------
-      # Build Emacs
-      # -------------------------
-      # - name: Build Emacs ${{ matrix.emacs-version }}
-      #   run: |
-      #     git clone --depth 1 --filter=blob:none https://github.com/emacs-mirror/emacs.git
-      #     cd emacs
-      #     git fetch --depth 1 origin tag emacs-${{ matrix.emacs-version }}
-      #     git checkout emacs-${{ matrix.emacs-version }}
-
-      #     ./autogen.sh
-      #     ./configure \
-      #       LDFLAGS="-Wl,-rpath,$HOME/local/lib" \
-      #       --with-gnutls \
-      #       --with-zlib \
-      #       --without-native-compilation \
-      #       --with-tree-sitter \
-      #       --without-mailutils \
-      #       --without-pop \
-      #       --without-x \
-      #       --without-sound \
-      #       --without-sqlite3 \
-      #       --without-xml2 \
-      #       --without-threads \
-      #       --without-compress-install \
-      #       CFLAGS="-O2"
-      #     make -j$(nproc)
-      #     sudo make install
-
-      # -------------------------
-      # Build Fortran grammar (mscfd/master)
+      # Install tree-sitter CLI
       # -------------------------
       - name: Install tree-sitter CLI
         run: |
           npm install -g tree-sitter-cli@0.25.10
 
+      # -------------------------
+      # Build tree-sitter-fortran
+      # -------------------------
       - name: Build tree-sitter-fortran
         run: |
           git clone --depth 1 --single-branch --branch master \
             https://github.com/mscfd/tree-sitter-fortran.git
           cd tree-sitter-fortran
+
           echo "Grammar commit: $(git rev-parse HEAD)"
 
           tree-sitter generate
 
           cc -fPIC -c src/parser.c
           cc -fPIC -c src/scanner.c 2>/dev/null || true
+
           cc -shared parser.o scanner.o -o libtree-sitter-fortran.so || \
             cc -shared parser.o -o libtree-sitter-fortran.so
+
           mkdir -p ~/.emacs.d/tree-sitter
           cp libtree-sitter-fortran.so ~/.emacs.d/tree-sitter/
 


### PR DESCRIPTION
Build emacs version by hand to fix workflow yaml files. The emacs builds of purcell/setup-emacs@master were switched to treesitter-0.26, which is ncompatible with emacs-30 branch.