### PR TITLE
Rework keybindings and add a transient prefix

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1,7 +1,7 @@
 # f90-ts-mode User Manual
 
 This manual provides a comprehensive overview and technical documentation for **f90-ts-mode**,
-a major mode for editing **Fortran 90 / Fortran 2003** (and newer) based on Emacs’s built-in **Tree-sitter** support.
+a major mode for editing **Fortran 90 / Fortran 2003** (and newer) based on Emacs's built-in **Tree-sitter** support.
 
 The mode is still under **development**. The [Roadmap](READEME.md#roadmap) lists missing or incomplete feature planned
 for implementation.
@@ -162,20 +162,48 @@ placed somewhere in `init.el` (or elsewhere).
 
 ### Keybindings
 
-The mode sets the following default mode local keybindings:
-```elisp
-(define-key f90-ts-mode-map (kbd "C-<tab>") #'f90-ts-indent-and-complete-stmt)
-(define-key f90-ts-mode-map (kbd "<backtab>")         #'f90-ts-indent-for-tab-command-2) ; S-<tab>
-(define-key f90-ts-mode-map (kbd "C-S-<iso-lefttab>") #'f90-ts-indent-for-tab-command-3) ; Linux
-(define-key f90-ts-mode-map (kbd "C-<backtab>")       #'f90-ts-indent-for-tab-command-3) ; Windows?
+The mode sets the following default mode-local keybindings:
 
-(define-key f90-ts-mode-map (kbd "A-<return>") 'f90-ts-break-line)
-(define-key f90-ts-mode-map (kbd "A-<backspace>") #'f90-ts-join-line-prev)
-(define-key f90-ts-mode-map (kbd "A-<delete>") #'f90-ts-join-line-next)
-(define-key f90-ts-mode-map (kbd "A-\\") #'f90-ts-enlarge-region)
-(define-key f90-ts-mode-map (kbd "A-0") #'f90-ts-child0-region)
-(define-key f90-ts-mode-map (kbd "A-[") #'f90-ts-prev-region)
-(define-key f90-ts-mode-map (kbd "A-]") #'f90-ts-next-region)
+```elisp
+;; TAB family
+(define-key map (kbd "C-<tab>")           #'f90-ts-indent-and-complete-stmt)
+(define-key map (kbd "<backtab>")         #'f90-ts-indent-for-tab-command-2) ; S-<tab>
+(define-key map (kbd "C-S-<iso-lefttab>") #'f90-ts-indent-for-tab-command-3) ; Linux
+(define-key map (kbd "C-<backtab>")       #'f90-ts-indent-for-tab-command-3) ; Windows?
+
+;; other keybindings inspired by f90-mode
+(define-key map (kbd "C-<return>")        #'f90-ts-break-line)
+(define-key f90-ts-mode-map (kbd "C-c ;") #'f90-ts-comment-region-default)
+(define-key f90-ts-mode-map (kbd "C-c '") #'f90-ts-comment-region-custom)
+
+;; C-c C-f — transient popup (see below)
+(define-key map (kbd "C-c C-f") #'f90-ts-transient)
+```
+
+#### Transient popup (`C-c C-f`)
+
+Pressing `C-c C-f` opens a transient keymap window. listing all major
+commands grouped by category.
+
+The popup is defined as `f90-ts-transient` and covers:
+
+| Section                   | Keys                            | Commands                                        |
+|---------------------------|---------------------------------|-------------------------------------------------|
+| **Indentation**           | `TAB` `s` `I` `E`               | Indent line / statement / region / smart end    |
+| **Line editing**          | `RET` `j` `J`                   | Break line, join with prev/next                 |
+| **Comment region**        | `c` `C`                         | Default and custom prefix                       |
+| **Structural navigation** | `a` `e` `p` `n`                 | Procedure (beginning, end, prev, next)          |
+|                           | `M-a` `M-e` `M-p` `M-n`         | Type (beginning, end, prev, next)               |
+|                           | `C-M-a` `C-M-e` `C-M-p` `C-M-n` | Interface (beginning, end, prev, next)          |
+| **Region**                | `r` `0` `[` `]`                 | Enlarge, child-0, prev, next                    |
+| **Xref**                  | `.` `,` `/` `<` `>`             | Definitions, references, apropos, back, forward |
+| **Navigation side panel** | `b` `f`                         | Open and focus nav buffer                       |
+
+The entire popup can be bound to a different prefix by:
+
+```elisp
+(define-key f90-ts-mode-map "..." #'f90-ts-transient)
+(keymap-unset f90-ts-mode-map "C-c C-f") ; remove default
 ```
 
 
@@ -304,7 +332,7 @@ alignment columns, always include the continued line position among the set of c
 Behaviour of indentation of a region and of a line are controlled by `f90-ts-indent-list-region`
 and `f90-ts-indent-list-line`, respectively.
 There are also variants `f90-ts-indent-list-line-2` and `f90-ts-indent-list-line-3`, which are
-used by functions bound to Shift+TAB and Control+Shift+TAB by default.
+used by functions bound to `<backtab>` (S-`TAB`) and `C-S-<iso-lefttab>` / `C-<backtab>` by default.
 
 Also check out [Continued statements and blocks](#indentation-of-continued-statements-and-blocks).
 
@@ -378,7 +406,7 @@ For incomplete statements on continued lines or incomplete structure blocks,
 indentation is sometimes not correct, due to an incomplete AST produced by the parser.
 
 Indentation of continued statements from begin of statement to line at point is done by
-`f90-ts-indent-and-complete-stmt`, which is bound to `C-<tab>`.
+`f90-ts-indent-and-complete-stmt`, which is bound to `C-<tab>` and to `s` in the transient popup.
 
 This same function also indents a whole block if executed at its `end struct` line.
 
@@ -386,14 +414,16 @@ This same function also indents a whole block if executed at its `end struct` li
 ### Xref
 
 The mode provides a minimal buffer local implementation of xref functions. In particular, the following
-functions can be used to find definitions and references of symbols (keybindings are the default ones):
+functions can be used to find definitions and references of symbols. Default Emacs xref keybindings
+apply, and all are also accessible via the transient popup (`C-c C-f`):
 
-| Function: keybinding           | Description                          |
-|--------------------------------|--------------------------------------|
-| `xref-find-definitions`: `M-.` | Jump to definition                   |
-| `xref-find-references`: `M-?`  | Find all references                  |
-| `xref-find-apropos`: `C-M-.`   | Find symbols matching regexp pattern |
-| `xref-go-back`: `M-,`          | Pop back                             |
+| Function                | Default | Popup | Description                  |
+|-------------------------|---------|-------|------------------------------|
+| `xref-find-definitions` | `M-.`   | `.`   | Jump to definition           |
+| `xref-find-references`  | `M-?`   | `,`   | Find all references          |
+| `xref-find-apropos`     | `C-M-.` | `/`   | Find symbols matching regexp |
+| `xref-go-back`          | `M-,`   | `<`   | Pop back                     |
+| `xref-go-forward`       | `C-M-,` | `>`   | Go forward                   |
 
 
 ### Imenu
@@ -414,7 +444,8 @@ with submenus for structures that contain other items.
 
 The navigation buffer provides a persistent side panel showing the structure of the current
 Fortran source buffer. It is based on the same tree as offered in the [Navigation menu](#navigation-menu).
-It can be opened with `f90-ts-nav-buffer-open` and focused with `f90-ts-nav-buffer-focus`.
+It can be opened with `f90-ts-nav-buffer-open` (`b` in the transient popup) and focused with
+`f90-ts-nav-buffer-focus` (`f` in the transient popup).
 
 The panel prints the tree, reflecting the nesting of program units.
 Entries are colour-coded by kind using customizable faces:
@@ -449,8 +480,9 @@ Keybindings in the navigation buffer:
 
 Inspired by the legacy f90 mode as well. Continued lines can be created by breaking a line or reduced
 by joining two consecutive lines connected by continuation symbol `&`.
-Functions for break and join operations are bound to `A-<return>` (break),
-`A-<backspace>` (join with previous line) and `A-<delete>` (join with next line).
+The line break function is bound to `C-<return>`.
+All break and join functions are available via the transient popup (`C-c C-f`)
+under keys `RET`, `j` and `J`.
 
 
 #### Breaking lines
@@ -486,7 +518,10 @@ Joining of comment lines or openmp statements is not yet implemented as well.
 
 This is also a feature inspired by the legacy f90 mode, but with a number of extensions.
 The selected region is (un)commented with a default or with a selectable prefix from a customizable list.
-```
+Both functions are accessible via the transient popup (`C-c C-f`) under keys `c` and `C`, and also
+have legacy-style direct bindings:
+
+```elisp
 (define-key f90-ts-mode-map (kbd "C-c ;") #'f90-ts-comment-region-default)
 (define-key f90-ts-mode-map (kbd "C-c '") #'f90-ts-comment-region-custom)
 ```
@@ -507,21 +542,15 @@ any blanks to keep original indentation of commented code.
 
 ### Mark region based on tree-sitter nodes
 
-Regions can be selected, enlarged, shrunk or moved based on tree-sitter nodes:
-Available functions are:
+Regions can be selected, enlarged, shrunk or moved based on tree-sitter nodes.
+Key bindings are provided in the transient popup (`C-c C-f`) under the Region section:
 
-| Function                         | Description                                                                 |
-|----------------------------------|-----------------------------------------------------------------------------|
-| `f90-ts-enlarge-region`          | Find smallest parent node of existing region which is strictly larger       |
-| `f90-ts-child0-region`           | Reduce existing region to a first (grand)child which is strictly smaller    |
-| `f90-ts-prev-region`             | Move selected region to previous sibling                                    |
-| `f90-ts-next-region`             | Move selected region to next sibling                                        |
-
-Default Keybindings:
- * (define-key map (kbd "A-\\") #'f90-ts-enlarge-region)
- * (define-key map (kbd "A-0") #'f90-ts-child0-region)
- * (define-key map (kbd "A-[") #'f90-ts-prev-region)
- * (define-key map (kbd "A-]") #'f90-ts-next-region)
+| Function                         | Popup key | Description                                                              |
+|----------------------------------|-----------|--------------------------------------------------------------------------|
+| `f90-ts-enlarge-region`          | `r`       | Find smallest parent node of existing region which is strictly larger    |
+| `f90-ts-child0-region`           | `0`       | Reduce existing region to a first (grand)child which is strictly smaller |
+| `f90-ts-prev-region`             | `[`       | Move selected region to previous sibling                                 |
+| `f90-ts-next-region`             | `]`       | Move selected region to next sibling                                     |
 
 
 ## Testing with ERT

--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ including syntax highlighting, indentation, navigation, and structural editing f
 - Navigation (defun, things, Xref, tree as submenu and as side panel buffer)
 
 
+## Keybindings
+
+The mode provides direct keybindings for the most frequent operations like indentation with `TAB`
+and a **transient popup** for discoverability of all commands:
+
+| Key                            | Description                      |
+|--------------------------------|----------------------------------|
+| `C-c C-f`                      | Open the transient command popup |
+| `C-<tab>`                      | Indent & complete line           |
+| `C-<return>`                   | Break line                       |
+| `C-c ;`                        | Comment region (default prefix)  |
+| `C-c '`                        | Comment region (custom prefix)   |
+
+Pressing `C-c C-f` opens a transient popup grouping all major commands by category.
+
+For the full keybinding reference see the
+[Keybindings section in the manual](MANUAL.md#keybindings).
+
+
 ## Installation
 
 This mode requires **Emacs 30+** and a compatible Tree-sitter Fortran grammar.

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -71,6 +71,7 @@
 (require 'cl-lib)
 (require 'treesit)
 (require 'xref)
+(require 'transient)
 
 ;; hl-line is used for the navigation buffer
 (require 'hl-line)
@@ -548,34 +549,7 @@ seem to make much sense."
 
 
 ;;;-----------------------------------------------------------------------------
-;;; keymap and syntax table
-
-(defvar f90-ts-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-<tab>") #'f90-ts-indent-and-complete-stmt)
-    ; <tab> is bound to indent-for-tab-command by default
-    (define-key map (kbd "<backtab>")         #'f90-ts-indent-for-tab-command-2) ; S-<tab>
-    (define-key map (kbd "C-S-<iso-lefttab>") #'f90-ts-indent-for-tab-command-3) ; Linux
-    (define-key map (kbd "C-<backtab>")       #'f90-ts-indent-for-tab-command-3) ; Windows?
-
-    (define-key map (kbd "A-<return>") 'f90-ts-break-line)
-    (define-key map (kbd "A-<backspace>") #'f90-ts-join-line-prev)
-    (define-key map (kbd "A-<delete>") #'f90-ts-join-line-next)
-    (define-key map (kbd "A-\\") #'f90-ts-enlarge-region)
-    (define-key map (kbd "A-0") #'f90-ts-child0-region)
-    (define-key map (kbd "A-[") #'f90-ts-prev-region)
-    (define-key map (kbd "A-]") #'f90-ts-next-region)
-
-    (define-key map (kbd "C-A-a") #'f90-ts-thing-beginning-of-procedure)
-    (define-key map (kbd "C-A-e") #'f90-ts-thing-end-of-procedure)
-    (define-key map (kbd "C-A-p") #'f90-ts-thing-prev-procedure)
-    (define-key map (kbd "C-A-n") #'f90-ts-thing-next-procedure)
-
-    (define-key map (kbd "C-c C-t") #'f90-ts-nav-buffer-open)
-    (define-key map (kbd "C-c C-f") #'f90-ts-nav-buffer-focus)
-    map)
-  "Keymap for `f90-ts-mode'.")
-
+;;; syntax table
 
 (defvar f90-ts-mode-syntax-table
   (let ((table (make-syntax-table)))
@@ -615,6 +589,130 @@ seem to make much sense."
 
     table)
   "Syntax table for `f90-ts-mode'.")
+
+
+;;;-----------------------------------------------------------------------------
+;;; keymap
+
+
+;; transient is used instead (but keep it for a while)
+;;
+;; (define-prefix-command 'f90-ts-prefix-map)
+;; ;; indentation
+;; (define-key f90-ts-prefix-map (kbd "<tab>") #'f90-ts-indent-and-complete-line)
+;; (define-key f90-ts-prefix-map (kbd "s")     #'f90-ts-indent-and-complete-stmt)
+;; (define-key f90-ts-prefix-map (kbd "I")     #'f90-ts-indent-and-complete-region)
+;; (define-key f90-ts-prefix-map (kbd "E")     #'f90-ts-complete-smart-end-region)
+
+;; ;; line editing
+;; (define-key f90-ts-prefix-map (kbd "RET") #'f90-ts-break-line)
+;; (define-key f90-ts-prefix-map (kbd "j")   #'f90-ts-join-line-prev)
+;; (define-key f90-ts-prefix-map (kbd "J")   #'f90-ts-join-line-next)
+
+;; ;; comment region
+;; (define-key f90-ts-prefix-map (kbd "c") #'f90-ts-comment-region-default)
+;; (define-key f90-ts-prefix-map (kbd "C") #'f90-ts-comment-region-custom)
+
+;; ;; navigation
+;; ;; procedure
+;; (define-key f90-ts-prefix-map (kbd "a") #'f90-ts-thing-beginning-of-procedure)
+;; (define-key f90-ts-prefix-map (kbd "e") #'f90-ts-thing-end-of-procedure)
+;; (define-key f90-ts-prefix-map (kbd "p") #'f90-ts-thing-prev-procedure)
+;; (define-key f90-ts-prefix-map (kbd "n") #'f90-ts-thing-next-procedure)
+
+;; ;; type
+;; (define-key f90-ts-prefix-map (kbd "M-a") #'f90-ts-thing-beginning-of-type)
+;; (define-key f90-ts-prefix-map (kbd "M-e") #'f90-ts-thing-end-of-type)
+;; (define-key f90-ts-prefix-map (kbd "M-p") #'f90-ts-thing-prev-type)
+;; (define-key f90-ts-prefix-map (kbd "M-n") #'f90-ts-thing-next-type)
+
+;; ;; interface
+;; (define-key f90-ts-prefix-map (kbd "C-M-a") #'f90-ts-thing-beginning-of-interface)
+;; (define-key f90-ts-prefix-map (kbd "C-M-e") #'f90-ts-thing-end-of-interface)
+;; (define-key f90-ts-prefix-map (kbd "C-M-p") #'f90-ts-thing-prev-interface)
+;; (define-key f90-ts-prefix-map (kbd "C-M-n") #'f90-ts-thing-next-interface)
+
+;; ;; region
+;; (define-key f90-ts-prefix-map (kbd "r") #'f90-ts-enlarge-region)
+;; (define-key f90-ts-prefix-map (kbd "0") #'f90-ts-child0-region)
+;; (define-key f90-ts-prefix-map (kbd "[") #'f90-ts-prev-region)
+;; (define-key f90-ts-prefix-map (kbd "]") #'f90-ts-next-region)
+
+;; ;; xref
+;; (define-key f90-ts-prefix-map (kbd ".") #'xref-find-definitions)
+;; (define-key f90-ts-prefix-map (kbd ",") #'xref-find-references)
+;; (define-key f90-ts-prefix-map (kbd "/") #'xref-find-apropos)
+
+;; ;; navigation side panel
+;; (define-key f90-ts-prefix-map (kbd "b")   #'f90-ts-nav-buffer-open)
+;; (define-key f90-ts-prefix-map (kbd "f")   #'f90-ts-nav-buffer-focus)
+
+;; ;; transient popup itself (? or C-c C-f C-f / SPC to open)
+;; (define-key f90-ts-prefix-map (kbd "?")   #'f90-ts-transient)
+;; (define-key f90-ts-prefix-map (kbd "SPC") #'f90-ts-transient)
+
+
+(defvar f90-ts-mode-map
+  (let ((map (make-sparse-keymap)))
+    ;; TAB commands
+    (define-key map (kbd "C-<tab>")           #'f90-ts-indent-and-complete-stmt)
+    (define-key map (kbd "<backtab>")         #'f90-ts-indent-for-tab-command-2) ; S-<tab>
+    (define-key map (kbd "C-S-<iso-lefttab>") #'f90-ts-indent-for-tab-command-3) ; Linux
+    (define-key map (kbd "C-<backtab>")       #'f90-ts-indent-for-tab-command-3) ; Windows?
+
+    ;; other keybindings inspired by f90-mode
+    (define-key map (kbd "C-<return>") #'f90-ts-break-line)
+    (define-key map (kbd "C-c ;")      #'f90-ts-comment-region-default)
+    (define-key map (kbd "C-c '")      #'f90-ts-comment-region-custom)
+
+    ;; C-c C-f prefix for the transient menu
+    (define-key map (kbd "C-c C-f") #'f90-ts-transient)
+    map)
+  "Keymap for `f90-ts-mode'.")
+
+
+(transient-define-prefix f90-ts-transient ()
+  "F90 Tree-sitter Mode"
+  [["Indentation"
+    ("TAB" "Indent line"                       f90-ts-indent-and-complete-line)
+    ("s"   "Indent & complete statement"       f90-ts-indent-and-complete-stmt)
+    ("I"   "Indent & complete region"          f90-ts-indent-and-complete-region)
+    ("E"   "Complete end statements"           f90-ts-complete-smart-end-region)]
+   ["Line & comments"
+    ("RET" "Break line"                        f90-ts-break-line)
+    ("j"   "Join with previous line"           f90-ts-join-line-prev)
+    ("J"   "Join with next line"               f90-ts-join-line-next)
+    ("c"   "Comment region (default)"          f90-ts-comment-region-default)
+    ("C"   "Comment region (custom)"           f90-ts-comment-region-custom)]
+   ["Region"
+    ("r"   "Enlarge region"                    f90-ts-enlarge-region)
+    ("0"   "Child-0 region"                    f90-ts-child0-region)
+    ("["   "Previous region"                   f90-ts-prev-region)
+    ("]"   "Next region"                       f90-ts-next-region)]]
+  [["Procedure navigation"
+    ("a"   "Beginning"                         f90-ts-thing-beginning-of-procedure)
+    ("e"   "End"                               f90-ts-thing-end-of-procedure)
+    ("p"   "Previous"                          f90-ts-thing-prev-procedure)
+    ("n"   "Next"                              f90-ts-thing-next-procedure)]
+   ["Type navigation"
+    ("M-a" "Beginning"                         f90-ts-thing-beginning-of-type)
+    ("M-e" "End"                               f90-ts-thing-end-of-type)
+    ("M-p" "Previous"                          f90-ts-thing-prev-type)
+    ("M-n" "Next"                              f90-ts-thing-next-type)]
+   ["Interface navigation"
+    ("C-M-a" "Beginning"                       f90-ts-thing-beginning-of-interface)
+    ("C-M-e" "End"                             f90-ts-thing-end-of-interface)
+    ("C-M-p" "Previous"                        f90-ts-thing-prev-interface)
+    ("C-M-n" "Next"                            f90-ts-thing-next-interface)]
+   ["Xref"
+    ("."   "Find definition"                   xref-find-definitions)
+    (","   "Find references"                   xref-find-references)
+    ("/"   "Find apropos"                      xref-find-apropos)
+    ("<"   "Go back"                           xref-go-back)
+    (">"   "Go forward"                        xref-go-forward)]
+   ["Navigation panel"
+    ("b"   "Open nav buffer"                   f90-ts-nav-buffer-open)
+    ("f"   "Focus nav buffer"                  f90-ts-nav-buffer-focus)]])
 
 
 ;;;-----------------------------------------------------------------------------


### PR DESCRIPTION
Replace adhoc keybindings by a small selection of keybinding and a comprehensive set of transient bindings.