### PR TITLE
Correctly set the modified bit for complex indentation operations

### DIFF
--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -368,12 +368,13 @@ Special comments such as separators are determined by rules in
   "Determine whether and how to complete an end statement.
 If set to blink, perform completion and then jump to the opening clause of the
 completed statement.
-If set to no-blink perform completion without jumping.
+If set to no-blink perform completion without jumping, but print a message.
+If set to no-message just perform completion without jumping and any message.
 Value nil turns off smart end completion.
 
 Copied from prog mode `f90-mode'."
-  :type  '(choice (const blink) (const no-blink) (const nil))
-  :safe  (lambda (value) (memq value '(blink no-blink nil)))
+  :type  '(choice (const blink) (const no-blink) (const no-message) (const nil))
+  :safe  (lambda (value) (memq value '(blink no-blink complete nil)))
   :group 'f90-ts)
 
 
@@ -4248,18 +4249,19 @@ not happen, as `f90-ts--complete-end-structs' lists all supported structures."
 Either jump to the start of the structure or show opening statement in the
 message buffer.  Which action to perform depends on position and whether
 `blink' is set."
-  (let ((top-of-window (window-start))
-        (start-struct (treesit-node-start node-struct)))
-    (save-excursion
-      (goto-char start-struct)
-      (if (or (eq f90-ts-smart-end 'no-blink)
-              (< start-struct top-of-window))
-          (message "matches %s: %s"
-                   (what-line)
-                   (buffer-substring
-                    (line-beginning-position)
-                    (line-end-position)))
-        (sit-for blink-matching-delay)))))
+  (unless (eq f90-ts-smart-end 'no-message)
+    (let ((top-of-window (window-start))
+          (start-struct (treesit-node-start node-struct)))
+      (save-excursion
+        (goto-char start-struct)
+        (if (or (eq f90-ts-smart-end 'no-blink)
+                (< start-struct top-of-window))
+            (message "matches %s: %s"
+                     (what-line)
+                     (buffer-substring
+                      (line-beginning-position)
+                      (line-end-position)))
+          (sit-for blink-matching-delay))))))
 
 
 (defun f90-ts--complete-smart-end-end (node)

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -4351,12 +4351,18 @@ otherwise nil."
           (setq beg-marker (copy-marker beg t))
           (setq end-marker (copy-marker end t))
           (f90-ts--indent-and-complete-region-aux beg-marker end-marker)
-          (when (treesit-node-check node-struct 'outdated)
-            ;; remember that the region has been modified in case it was invoked
-            ;; by some line operation which wants to keep track of modifications
-            (setq f90-ts--indent-modified-outside-line t)
-            (setq node-struct-new (treesit-node-on (marker-position beg-marker)
-                                                   (marker-position end-marker)))))
+
+          ;; if something was modified, then treesit-node-on forces a reparse
+          ;; and node-probe /= node-struct, in this case set node-struct-new to node-probe
+          ;; otherwise leave node-struct-new at nil, signalling that the old node is still valid
+          (let ((node-probe (treesit-node-on (marker-position beg-marker)
+                                             (marker-position end-marker))))
+
+            (unless (treesit-node-eq node-struct node-probe)
+              (setq node-struct-new node-probe)
+              ;; signal that the region has been modified in case it was invoked
+              ;; by some line operation which wants to keep track of modifications
+              (setq f90-ts--indent-modified-outside-line t))))
       ;; revert to saved tab variant
       (setq f90-ts--align-continued-variant-tab variant-saved)
       (when beg-marker (set-marker beg-marker nil))

--- a/test/f90-ts-mode-test.el
+++ b/test/f90-ts-mode-test.el
@@ -811,7 +811,7 @@ result region."
 
 
 (defun f90-ts-mode-test--modify-region (command)
-  "Setup region and apply COMMAND for modifying region.
+  "Setup pre-selected region and apply COMMAND for modifying region.
 Set up region from @ to | markers, then call COMMAND and reinsert @..| markers
 for modified region."
   (let ((pos (point)))
@@ -840,6 +840,28 @@ point at 1+end of region."
       (goto-char beg)
       (insert "@")
       (goto-char (1+ end)))))
+
+
+;;------------------------------------------------------------------------------
+;; modified bit helpers
+
+(defun f90-ts-mode-test--modified-check (modified command)
+  "Test function for adding a final symbol signalling final modified status.
+First set bit to MODIFIED, then execute COMMAND and finally insert the marker
+`**' for modified and `oo' for not modified."
+  (set-buffer-modified-p modified)
+  (funcall command)
+  (f90-ts-mode-test--insert-mod-marker))
+
+
+(defun f90-ts-mode-test--insert-mod-marker ()
+  "Query modified status of buffer and insert a marker at end of buffer.
+If buffer was modified, insert `**' otherwise insert '--'."
+  (save-excursion
+    (goto-char (point-max))
+    (if (buffer-modified-p)
+        (insert "**\n")
+      (insert "oo\n"))))
 
 
 ;;------------------------------------------------------------------------------
@@ -905,7 +927,8 @@ point at 1+end of region."
    "break_line.erts"
    "join_line.erts"
    "mark_region.erts"
-   "comment_region.erts"))
+   "comment_region.erts"
+   "modified_bit.erts"))
 
 
 ;; expensive tests

--- a/test/f90-ts-mode-test.el
+++ b/test/f90-ts-mode-test.el
@@ -142,6 +142,7 @@ without final newline."
     (f90-ts-indent-expr-assign-default . 2)
     (f90-ts-indent-expr-assign-assoc-op . 1)
     (f90-ts-indent-declaration . 3)
+    (f90-ts-smart-end . no-message)
     (f90-ts-leading-ampersand . nil)
     (f90-ts-leading-ampersand-style . (indent . 3))
     (f90-ts-special-comment-rules . ,f90-ts-mode-test--special-comment-rules)

--- a/test/resources/modified_bit.erts
+++ b/test/resources/modified_bit.erts
@@ -1,0 +1,206 @@
+Point-Char: |
+
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (let ((f90-ts-leading-ampersand t))
+      (f90-ts-mode-test--modified-check nil #'f90-ts-indent-and-complete-stmt)))
+
+Name: stmt unchanged-modified 1
+=-=
+subroutine sub()
+     if (x) then
+     do while (y)
+     end do
+|     end if
+end subroutine sub
+=-=
+subroutine sub()
+     if (x) then
+          do while (y)
+          end do
+     end if|
+end subroutine sub
+**
+=-=-=
+
+Name: stmt unchanged-modified 2
+=-=
+! ampersand are removed and reinsert, so buffer is temporarily modified
+subroutine sub()
+     call foo(x1, &
+       &     x2, &
+        &     x4, &
+        &     x5)|
+end subroutine sub
+=-=
+! ampersand are removed and reinsert, so buffer is temporarily modified
+subroutine sub()
+     call foo(x1, &
+        &     x2, &
+        &     x4, &
+        &     |x5)
+end subroutine sub
+**
+=-=-=
+
+Name: stmt unchanged-unchanged 1
+=-=
+subroutine sub()
+     if (x) then
+          do while (y)
+          end do
+|     end if
+end subroutine sub
+=-=
+subroutine sub()
+     if (x) then
+          do while (y)
+          end do
+     end if|
+end subroutine sub
+oo
+=-=-=
+
+Name: stmt unchanged-unchanged 2
+=-=
+! ampersand are removed and reinsert, so buffer is temporarily modified
+subroutine sub()
+     call foo(x1, &
+        &     x2, &
+        &     x4, &
+        &     x5)|
+end subroutine sub
+=-=
+! ampersand are removed and reinsert, so buffer is temporarily modified
+subroutine sub()
+     call foo(x1, &
+        &     x2, &
+        &     x4, &
+        &     x5)|
+end subroutine sub
+oo
+=-=-=
+
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (f90-ts-mode-test--modified-check t #'f90-ts-indent-and-complete-stmt))
+
+Name: stmt modified-modified 1
+=-=
+subroutine sub()
+     if (x) then
+     do while (y)
+     end do
+|     end if
+end subroutine sub
+=-=
+subroutine sub()
+     if (x) then
+          do while (y)
+          end do
+     end if|
+end subroutine sub
+**
+=-=-=
+
+Name: stmt modified-unchanged 1
+=-=
+subroutine sub()
+     if (x) then
+          do while (y)
+          end do
+|     end if
+end subroutine sub
+=-=
+subroutine sub()
+     if (x) then
+          do while (y)
+          end do
+     end if|
+end subroutine sub
+**
+=-=-=
+
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (f90-ts-mode-test--modified-check nil #'f90-ts-indent-and-complete-line))
+
+Name: line unchanged-modified 1
+=-=
+subroutine sub()
+     if (x) then
+     do while (y)
+     end do
+|     end
+end subroutine sub
+=-=
+subroutine sub()
+     if (x) then
+     do while (y)
+     end do
+     end if|
+end subroutine sub
+**
+=-=-=
+
+Name: line unchanged-unchanged 1
+=-=
+subroutine sub()
+     if (x) then
+          do while (y)
+          end do
+|     end if
+end subroutine sub
+=-=
+subroutine sub()
+     if (x) then
+          do while (y)
+          end do
+     end if|
+end subroutine sub
+oo
+=-=-=
+
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (f90-ts-mode-test--modified-check t #'f90-ts-indent-and-complete-line))
+
+Name: line modified-modified 1
+=-=
+subroutine sub()
+     if (x) then
+     do while (y)
+     end do
+|     end
+end subroutine sub
+=-=
+subroutine sub()
+     if (x) then
+     do while (y)
+     end do
+     end if|
+end subroutine sub
+**
+=-=-=
+
+Name: line modified-unchanged 1
+=-=
+subroutine sub()
+     if (x) then
+          do while (y)
+          end do
+|     end if
+end subroutine sub
+=-=
+subroutine sub()
+     if (x) then
+          do while (y)
+          end do
+     end if|
+end subroutine sub
+**
+=-=-=


### PR DESCRIPTION
Due to lazy parsing, an outdated check a structure node was incorrect, leading to wrongly clearing the modified bit.

Also fix a severe performance bug (do not invoke sit-for in smart-end-show function), which became apparent for the modified_bit.erts tests.