### PR TITLE
Fix trailing blanks in uncommented line during comment region operation

### DIFF
--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -5276,7 +5276,10 @@ Otherwise mark the region spanned by the node itself (like enlarge-region)."
     (cl-loop
      do (cond
          ((looking-at uncomment-re)
-          (delete-region (match-beginning 1) (match-end 1)))
+          (delete-region (match-beginning 1) (match-end 1))
+          (when (looking-at-p "[ \t]+$")
+            ;; after deletion, we have an empty line, remove trailing blanks
+            (delete-region (point) (line-end-position))))
          ((looking-at-p "[ \t]*$")
           ;; avoid trailing blanks on empty lines
           (insert prefix-trimmed))

--- a/test/resources/comment_region.erts
+++ b/test/resources/comment_region.erts
@@ -488,3 +488,24 @@ subroutine sub_trailing_2()
 !!$
 |end subroutine sub_trailing_2
 =-=-=
+
+
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (f90-ts-comment-region-custom 18 51 "! "))
+
+Name: uncomment region trailing blank 1
+=-=
+subroutine xxx()
+|     ! x = 6
+     !
+     ! y = 5
+end subroutine xxx
+=-=
+subroutine xxx()
+     x = 6
+
+     y = 5
+|end subroutine xxx
+=-=-=


### PR DESCRIPTION
Commenting an already commented region uncomments that region. If a line contains only the comment prefix and this prefix is indented, then the line becomes empty after removing the prefix, but contains trailing blanks. These are now removed.
