### PR TITLE
Add support for string literals on continued lines

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -507,11 +507,19 @@ One whitespace character is left after putting the second line at the end of the
 Comments at end of first line or in between the two lines are not allowed currently.
 (It is not quite clear what should be done with such comments.)
 
+Joining within a string literal is implemented. Currently comments within string literals are not supported
+by the tree-sitter grammar and hence do not work anyway.
+
+Joining of openmp statements is not yet implemented.
+
+If point is on an empty line (not necessarily within a continued statement),
+then previous (prev variant) or subsequent (next variant) empty lines are removed,
+but nothing is joined in any case.
+
+Intermediate empty lines are removed, if point is on a non-empty line.
+
 The `prev` variant joins current line with previous (non-empty) line.
 The `next` variant joins current line with next (non-empty) line.
-
-If point is on an empty line within a continued statement, then nothing is joined.
-Joining of comment lines or openmp statements is not yet implemented as well.
 
 
 

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -673,7 +673,7 @@ seem to make much sense."
 
 
 (transient-define-prefix f90-ts-transient ()
-  "F90 Tree-sitter Mode"
+  "F90 Tree-sitter Mode."
   [["Indentation"
     ("TAB" "Indent line"                       f90-ts-indent-and-complete-line)
     ("s"   "Indent & complete statement"       f90-ts-indent-and-complete-stmt)
@@ -4890,10 +4890,6 @@ Move point to first character on the line after it was originally placed."
     (back-to-indentation)))
 
 
-;; note: due to comments and empty lines, a simple forward-line or backward-line
-;; does not seem possible easily, instead we should check and reconstruct the
-;; (&, comment*, &) sequence of nodes and use it for navigation and changes,
-;; and to unify the two join variants
 (defun f90-ts--join-line-aux (first secnd is-prev)
   "Join lines between nodes FIRST and SECND.
 For continued lines without comments in between, FIRST and SECND are the two
@@ -4904,6 +4900,9 @@ and removes any empty lines in-between.
 If IS-PREV is non-nil, then this is called from `f90-ts-join-line-prev',
 otherwise from `f90-ts-join-line-next.'  This is used to place point after
 deleting intermediate empty lines or if nothing can be joined."
+  ;; note: due to comments and empty lines, a simple forward-line or backward-line
+  ;; does not seem possible easily, instead reconstruct the (&, comment*, &)
+  ;; sequence of nodes and use it for navigation and changes
   (let* ((is-amp-1st (f90-ts--node-type-p first "&"))
          (is-amp-2nd (f90-ts--node-type-p secnd "&"))
          (is-comment-1st (f90-ts--node-type-p first "comment"))
@@ -4972,6 +4971,22 @@ deleting intermediate empty lines or if nothing can be joined."
         (message "join failed: joining not possible")))))
 
 
+(defun f90-ts--join-line-string (node pos1 pos2)
+  "Join previous line with current line both belonging to a continued string.
+The string is provided by NODE, which is of type string_literal.
+Positions POS1 and POS2 are end of previous line and start of current line."
+  (cl-assert (f90-ts--node-type-p node "string_literal")
+             nil "node is not a string literal")
+  (cl-assert (eq (char-before pos1) ?&)
+             nil "character before pos1 is not an ampersand")
+  (cl-assert (eq (char-after pos2) ?&)
+             nil "character at pos2 is not an ampersand")
+  (let ((beg (1- pos1))
+        (end (1+ pos2)))
+    (delete-region beg end)
+    (goto-char beg)))
+
+
 (defun f90-ts-join-line-prev ()
   "Join previous line with the current one, if part of a continued statement.
 This is (partially) a counterpart to `f90-ts-break-line'.
@@ -4995,12 +5010,17 @@ If previous line has comments (at end, next line etc.) joining is not done."
                    (skip-chars-forward "[ \t\n]")
                    (point)))
            (first (f90-ts--node-on-pos pos1 nil))
-           (secnd (f90-ts--node-on-pos pos2 nil)))
+           (secnd (f90-ts--node-on-pos pos2 nil))
+           (is-cont-str (and (f90-ts--node-type-p first "string_literal")
+                             (f90-ts--node-type-p secnd "string_literal")
+                             (treesit-node-eq first secnd))))
       ;;(f90-ts-log :joinprev "pos1: %s, %s" pos1 first)
       ;;(f90-ts-log :joinprev "pos2: %s, %s" pos2 secnd)
+      ;;(f90-ts-log :joinprev "is-cont-str: %s" is-cont-str)
       (cl-assert (or first (= pos1 (point-min)))
                  nil "first node is nil with wrong pos1")
       (cl-assert (or (null first)
+                     is-cont-str
                      (or (= pos1 (treesit-node-end first))
                          ;; note that a comment might have trailing blanks, hence pos1
                          ;; might differ from node end position
@@ -5008,14 +5028,26 @@ If previous line has comments (at end, next line etc.) joining is not done."
                               (string-blank-p (buffer-substring pos1 (treesit-node-end first))))))
                  nil "first node has wrong end position %s" first)
       (cl-assert secnd nil "secnd node is nil")
-      (cl-assert (= pos2 (treesit-node-start secnd))
+      (cl-assert (or (= pos2 (treesit-node-start secnd))
+                     is-cont-str)
                  nil "secnd node has wrong start position")
 
-      (if first
-          (f90-ts--join-line-aux first secnd t)
-        ;; all lines prior to point are empty, delete them
-        (back-to-indentation)
-        (delete-region pos1 (point)))))))
+      (cond
+       (is-cont-str
+        ;; check that previous line is not a comment
+        ;; (within the string, not yet supported by tree-sitter grammar)
+        (if (eq (char-before pos1) ?&)
+            ;; first and secnd are equal (established in is-cont-str)
+            (f90-ts--join-line-string first pos1 pos2)
+          (message "join failed: joining not possible (comment within string literal)")))
+
+      (first
+       (f90-ts--join-line-aux first secnd t))
+
+      (t
+       ;; all lines prior to point are empty, delete them
+       (back-to-indentation)
+       (delete-region pos1 (point))))))))
 
 
 (defun f90-ts-join-line-next ()
@@ -5041,11 +5073,16 @@ If continued line has comments (at end, next line etc.) joining is not done."
                    (skip-chars-forward "[ \t\n]")
                    (point)))
            (first (f90-ts--node-on-pos pos1 nil))
-           (secnd (f90-ts--node-on-pos pos2 nil)))
+           (secnd (f90-ts--node-on-pos pos2 nil))
+           (is-cont-str (and (f90-ts--node-type-p first "string_literal")
+                             (f90-ts--node-type-p secnd "string_literal")
+                             (treesit-node-eq first secnd))))
       ;;(f90-ts-log :joinnext "pos1: %s, %s" pos1 first)
       ;;(f90-ts-log :joinnext "pos2: %s, %s" pos2 secnd)
+      ;;(f90-ts-log :joinnext "is-cont-str: %s" is-cont-str)
       (cl-assert first nil "first node is nil")
       (cl-assert (or (= pos1 (treesit-node-end first))
+                     is-cont-str
                      ;; note that a comment might have trailing blanks, hence pos1
                      ;; might differ from node end position
                      (and (f90-ts--node-type-p first "comment")
@@ -5058,13 +5095,24 @@ If continued line has comments (at end, next line etc.) joining is not done."
                      (= pos2 (point-max)))
                  nil "secnd node is translation_unit with with wrong pos2")
       (cl-assert (or (f90-ts--node-type-p secnd "translation_unit")
+                     is-cont-str
                      (= pos2 (treesit-node-start secnd)))
                  nil "secnd node has wrong start position")
-      (if (not (f90-ts--node-type-p secnd "translation_unit"))
-          (f90-ts--join-line-aux first secnd nil)
+      (cond
+       ((f90-ts--node-type-p secnd "translation_unit")
         ;; all lines after point are empty, delete them
         (end-of-line)
-        (delete-region (point) pos2))))))
+        (delete-region (point) pos2))
+
+       (is-cont-str
+        ;; check that previous line is not a comment
+        ;; (within the string, not yet supported by tree-sitter grammar)
+        (if (eq (char-after pos2) ?&)
+            ;; first and secnd are equal (established in is-cont-str)
+            (f90-ts--join-line-string first pos1 pos2)
+          (message "join failed: joining not possible (comment within string literal)")))
+       (t
+        (f90-ts--join-line-aux first secnd nil)))))))
 
 
 ;;;-----------------------------------------------------------------------------

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -3840,6 +3840,11 @@ The main purpose is to fill the indentation cache for a new run.")
    ;; indent-region operations with buffering)
    (continued-line-cache-start parent 0)
 
+   ;; continued strings need special care, the ampersands do not appear as
+   ;; separate nodes, (treesit-node-at pos) at indentation position returns
+   ;; the string_literal, which starts at some previous line
+   ((n-p-gp nil "string_literal" nil) parent 0)
+
    ;; it is easy to see whether we are on a continued line (not the first line
    ;; of a multiline statement, only subsequent lines), but handling specific
    ;; cases is not possible with just some simple n-p-gp pattern,

--- a/test/f90-ts-mode-test.el
+++ b/test/f90-ts-mode-test.el
@@ -905,12 +905,13 @@ If buffer was modified, insert `**' otherwise insert '--'."
  '(f90-ts-indent-and-complete-line))
 
 
-;; alignment tests, leave as is, the alignment variant to apply
-;; should be specified for each test header (default: keep-or-primary)
+;; alignment tests, leave as is, apply no preparation,
+;; (otherwise alignment might change depending on keep-or-primary etc. options)
 (f90-ts-mode-test--prep-act-register
  "f90-ts-mode-test-std"
  '("indent_region_align_misc.erts"
    "indent_region_align_expr.erts"
+   "indent_region_align_string.erts"
    "indent_region_leading_amp.erts")
  '(nil ; no preparation
    )

--- a/test/resources/indent_region_align_string.erts
+++ b/test/resources/indent_region_align_string.erts
@@ -1,0 +1,45 @@
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (when f90-ts-mode-test--prepare-fn
+      (funcall f90-ts-mode-test--prepare-fn))
+    (funcall f90-ts-mode-test--action-fn))
+
+Point-Char: |
+
+Name: continued string 1
+=-=
+subroutine string1()
+     str = "012&
+           &abc &
+           &uvw"
+end subroutine string1
+=-=-=
+
+Name: continued string 2
+=-=
+subroutine string2()
+str = "012&
+&abc &
+&uvw"
+end subroutine string2
+=-=
+subroutine string2()
+     str = "012&
+           &abc &
+           &uvw"
+end subroutine string2
+=-=-=
+
+Name: continued string 3
+=-=
+subroutine string3()
+     str = "012&
+           & &
+           &&
+           &abc &
+
+           &uvw&
+           xyz"
+end subroutine string3
+=-=-=

--- a/test/resources/join_line.erts
+++ b/test/resources/join_line.erts
@@ -195,7 +195,6 @@ end subroutine sub_1
 end subroutine sub_1
 =-=-=
 
-
 Name: join prev statement 14
 =-=
 subroutine sub_1()
@@ -205,6 +204,76 @@ end subroutine sub_1
 subroutine sub_1()
      |x = 65
 end subroutine sub_1
+=-=-=
+
+Name: join prev string 1
+=-=
+subroutine str1()
+     str = "012&
+           |&345"
+end subroutine str1
+=-=
+subroutine str1()
+     str = "012|345"
+end subroutine str1
+=-=-=
+
+Name: join prev string 2
+=-=
+subroutine str2()
+     str = "012&
+           &345"|
+end subroutine str2
+=-=
+subroutine str2()
+     str = "012|345"
+end subroutine str2
+=-=-=
+
+Name: join prev string 3
+=-=
+subroutine str3()
+     str = "012&
+
+
+|           &345"
+end subroutine str3
+=-=
+subroutine str3()
+     str = "012|345"
+end subroutine str3
+=-=-=
+
+Name: join prev string 4
+=-=
+subroutine str4()
+     str = "012  &
+
+
+           & |  345"
+end subroutine str4
+=-=
+subroutine str4()
+     str = "012  |   345"
+end subroutine str4
+=-=-=
+
+Name: join prev string 5
+=-=
+subroutine str5()
+     str = "012  &
+
+
+|
+
+           &   345"
+end subroutine str5
+=-=
+subroutine str5()
+     str = "012  &|
+
+           &   345"
+end subroutine str5
 =-=-=
 
 Name: join prev empty 1
@@ -471,9 +540,80 @@ subroutine sub_1()
 end subroutine sub_1
 =-=-=
 
-Remark erts parses the expected block always adding a final newline for the last line, which cannot be stipped,
-so the point marker cannot be placed in the expected position; as a consequence, add newline and check point
-position in Code block
+Name: join next string 1
+=-=
+subroutine str1()
+     str = "012&|
+           &345"
+end subroutine str1
+=-=
+subroutine str1()
+     str = "012|345"
+end subroutine str1
+=-=-=
+
+Name: join next string 2
+=-=
+subroutine str2()
+|     str = "012&
+           &345"
+end subroutine str2
+=-=
+subroutine str2()
+     str = "012|345"
+end subroutine str2
+=-=-=
+
+Name: join next string 3
+=-=
+subroutine str3()
+     str = |"012&
+
+
+           &345"
+end subroutine str3
+=-=
+subroutine str3()
+     str = "012|345"
+end subroutine str3
+=-=-=
+
+Name: join next string 4
+=-=
+subroutine str4()
+     str = "012  &|
+
+
+           &   345"
+end subroutine str4
+=-=
+subroutine str4()
+     str = "012  |   345"
+end subroutine str4
+=-=-=
+
+Name: join next string 5
+=-=
+subroutine str5()
+     str = "012  &
+
+
+|
+
+           &   345"
+end subroutine str5
+=-=
+subroutine str5()
+     str = "012  &
+
+
+           |&   345"
+end subroutine str5
+=-=-=
+
+erts functions parse the expected block always adding a final newline for the last line, which cannot be stripped.
+So the point marker cannot be placed in the expected position; as a consequence, check point position in Code block.
+This is done for the final join statement and some empty checks.
 
 Code:
   (lambda ()

--- a/test/todo/parse_tree.f90
+++ b/test/todo/parse_tree.f90
@@ -1,3 +1,12 @@
+! comment within a continued string is not yet supported by tree-sitter
+subroutine sub()
+   str = "012&
+         ! comment
+         &abc &
+         &uvw"
+end subroutine sub
+
+
 ! indent last line only, or do indent-region (which originally
 ! started smart end completion at last line)
 ! problem: parse tree is broken at this point (can/should we do anything about that)


### PR DESCRIPTION
Add basic indentation rules and break/join line operations for string literals.