### PR TITLE
Add indentation and font-locking for statement labels

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -26,6 +26,7 @@ for implementation.
   - [Smart end completion](#smart-end-completion)
   - [Indentation of continued statements with leading ampersand](#indentation-of-continued-statements-with-leading-ampersand)
   - [Indentation of continued statements and blocks](#indentation-of-continued-statements-and-blocks)
+  - [Indentation of statement labels](#indentation-of-statement-labels)
   - [Xref](#xref)
   - [Imenu](#imenu)
   - [Navigation menu](#navigation-menu)
@@ -410,6 +411,16 @@ Indentation of continued statements from begin of statement to line at point is 
 `f90-ts-indent-and-complete-stmt`, which is bound to `C-<tab>` and to `s` in the transient popup.
 
 This same function also indents a whole block if executed at its `end struct` line.
+
+
+### Indentation of statement labels
+
+Statements after statement labels are indented as if there is no label present.
+For the label itself there are two options. Either they are left-adjusted starting at a fixed
+column number, or right-adjusted with last digit of the label at the fixed column number.
+If there is not enough space, the statement itself is moved to the right to ensure at least one
+blank after the label.
+This is controlled by custom variable `f90-ts-stmt-label-column'.
 
 
 ### Xref

--- a/README.md
+++ b/README.md
@@ -100,17 +100,8 @@ Here is a small setup for the mode:
 There are a number of features still missing or incomplete.
 The following list provides features planned for implementation (somewhat ordered by priority):
 
-- Add support for strings on continued lines.
-  Those need specific placement of ampersand at start of continued line.
-  This concerns indentation as well as break and join operations.
-- Add support for statement labels. Example:
-```
-100 format(A, I8)
-    if (x < 0) goto 200
-    write(*, 100) "Negative value is expected: ", x
-    stop 1
-200 continue
-```
+- Complement alignment options for strings on continued lines.
+  (Also allow comments within continued strings. This is not yet supported by the fortran grammar.)
 - Fill operations similar to `f90-fill-region` and `f90-fill-paragraph`.
 - Support for (context-aware) `completion-at-point-function` (capf).
 - More list contexts. There is a number of list like contexts, which are not yet supported,
@@ -121,5 +112,3 @@ The following list provides features planned for implementation (somewhat ordere
 - `undo-boundary` to group internal changes to blocks of changes for undo.
   This mainly concerns complex indentation operations (like indentation of statements or region).
 - Electric insert similar to `f90-electric-insert`.
-
-

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -280,6 +280,21 @@ Value is a list of the form (TYPE VALUE) where TYPE is either:
   :group 'f90-ts)
 
 
+(defcustom f90-ts-stmt-label-column '(left . 0)
+  "Column specification for Fortran statement labels.
+A cons cell (ADJUSTMENT . COLUMN) where ADJUSTMENT is either
+`right-adjusted' or `left-adjusted', and COLUMN is a 0-based column number.
+With `right', the label's last digit lands on COLUMN (right-adjusted),
+so (right . 4) fills columns 0-4, the classic Fortran label field.
+With `left', the label's first digit starts on COLUMN (left-adjusted)."
+  :type '(cons
+          (choice
+           (const :tag "Right-adjusted (last digit at column)" right)
+           (const :tag "Left-adjusted  (first digit at column)" left))
+          (integer :tag "Column (0-based)"))
+  :group 'f90-ts)
+
+
 ;;;-----------------------------------------------------------------------------
 
 (defface f90-ts-font-lock-delimiter-face
@@ -1853,7 +1868,8 @@ rule but not for matched keywords, which are enforced with override=t."
    :language 'fortran
    :feature 'constant
    '(((boolean_literal) @font-lock-constant-face)
-     ((null_literal) @font-lock-constant-face))))
+     ((null_literal) @font-lock-constant-face)
+     (statement_label) @font-lock-constant-face)))
 
 
 (defun f90-ts--font-lock-rules-delimiter ()
@@ -4473,29 +4489,35 @@ continued statement plus the configured offset."
               f90-ts-leading-ampersand-style))))
 
 
-(defun f90-ts--indent-blank-leading-ampersand-line ()
-  "Handle a leading ampersand on the current line before indentation.
-If point is at an ampersand after moving to the indentation column,
-temporarily replace it with a space so that `treesit-indent' sees
-the first proper node on that line.  Returns blanked text if an
-ampersand was found (and replaced), nil otherwise."
+(defun f90-ts--indent-blank-leading-amp-or-label-line ()
+  "Blank a leading ampersand or statement label on the current line.
+Returns nil if neither was found, \\='(amp) if an ampersand was
+blanked, or \\='(label . label-text) if a statement label was
+blanked."
   (unless (f90-ts--point-on-empty-line-p)
     (save-excursion
       (back-to-indentation)
       (let ((c (char-after (point))))
-        ;; pre-check: only consider lines starting with ampersand
-        ;; later on: (and (>= c ?0) (<= c ?9)) for including statement labels
-        (when (and c (eq c ?&))
+        (cond
+         ;; leading ampersand
+         ((and c (eq c ?&))
           (let ((node (treesit-node-at (point))))
-            ;; a continued string has a leading ampersand, but the node starts on
-            ;; a previous line, these ampersands need to be excluding and must not be blanked
             (when (and node
-                       (= (point) (treesit-node-start node)))
-              (when (f90-ts--node-type-p node "&")
-                (let ((text (treesit-node-text node)))
-                  (delete-char 1)
-                  (insert " ")
-                  text)))))))))
+                       (= (point) (treesit-node-start node))
+                       (f90-ts--node-type-p node "&"))
+              (delete-char 1)
+              (insert " ")
+              '(amp))))
+         ;; statement label
+         ((and c (>= c ?0) (<= c ?9))
+          (let ((node (treesit-node-at (point))))
+            (when (and node
+                       (= (point) (treesit-node-start node))
+                       (f90-ts--node-type-p node "statement_label"))
+              (let ((text (treesit-node-text node)))
+                (delete-char (length text))
+                (insert (make-string (length text) ?\s))
+                (cons 'label text))))))))))
 
 
 (defun f90-ts--indent-restore-leading-ampersand-line ()
@@ -4515,53 +4537,96 @@ positioned as it is."
       (insert "&"))))
 
 
-(defun f90-ts--indent-blank-leading-ampersand-region (beg end)
-  "Replace leading ampersands with blanks for each line in BEG..END.
-Returns a vector of booleans (one per line) indicating which lines
-had a leading ampersand.  BEG and END must be markers or positions
-that remain valid after buffer modifications."
+(defun f90-ts--indent-restore-label-line (label-text)
+  "Restore a statement_label after indentation.
+It moves to the column determined by `f90-ts-stmt-label-column',
+inserting blanks and moving code to the right if necessary.
+Then it pastes LABEL-TEXT at the determined column, leaving the code
+positioned as it is.  A blank is ensured after the label."
+  (let* ((adj (car f90-ts-stmt-label-column))
+         (col (cdr f90-ts-stmt-label-column))
+         (label-len (length label-text))
+         (label-col (if (eq adj 'right)
+                        (max 0 (- col (1- label-len)))
+                      col)))
+    (back-to-indentation)
+    (let* ((indent-col (current-column))
+           (delta (- indent-col label-col)))
+      (if (<= delta 0)
+          (insert (make-string (- delta) ?\s)
+                  label-text
+                  " ")
+        (backward-char delta)
+        (insert label-text)
+        ;; we need to remove label-len blank, currently are delta blanks,
+        ;; hence if label-len <= delta-1 we can just remove the blanks and still have at least one left
+        ;; otherwise we only can remove delta-1
+        (delete-char (min label-len (1- delta)))))))
+
+
+(defun f90-ts--indent-restore-leading-amp-or-label-line (amp-or-label)
+  "Restore a leading ampersand or statement label from AMP-OR-LABEL.
+AMP-OR-LABEL is a value previously returned by
+`f90-ts--indent-blank-leading-amp-or-label-line'."
+  (when (or amp-or-label
+            (and f90-ts-leading-ampersand
+                 (f90-ts--node-type-p
+                  (f90-ts--first-node-on-line (point)) "&")))
+    (pcase amp-or-label
+      ((or 'nil '(amp))
+       ;; if nil there was no ampersand but there is a virtual ampersand
+       ;; signalling a continued line and f90-ts-leading-ampersand is non-nil
+       (f90-ts--indent-restore-leading-ampersand-line))
+      (`(label . ,label-text)
+       (f90-ts--indent-restore-label-line label-text))
+      (_ (cl-assert nil nil "unexpected value %S" amp-or-label)))))
+
+
+(defun f90-ts--indent-blank-leading-amp-or-label-region (beg end)
+  "Blank leading ampersands and statement labels for each line in BEG..END.
+Returns a vector (one entry per line) of values as returned by
+`f90-ts--indent-blank-leading-amp-or-label-line'."
   (save-excursion
     (goto-char beg)
     (let* ((line-beg (line-number-at-pos beg))
            (line-end (line-number-at-pos end))
            (n-lines  (- line-end line-beg -1))
-           (has-amp-vec    (make-vector n-lines nil)))
+           (vec      (make-vector n-lines nil)))
+      ;; after blanking loop, each element of the vector vec will be one of:
+      ;;   nil               – no amp, no label on the line
+      ;;   (amp)             – had a leading & on the line
+      ;;   (label . "12345") – had a statement label on the line
       (cl-loop
-       for ix from 0
+       for ix   from 0
        for line from line-beg to line-end
-       ;; note ix is equal to (- line line-beg)
        do (progn
             (cl-assert (= (line-number-at-pos (point)) line)
                        nil
-                       "f90-ts--indent-blank-leading-ampersand-region: line mismatch at index %d: expected line %d, got %d"
+                       "f90-ts--indent-blank-leading-amp-or-label-region: \
+line mismatch at index %d: expected %d, got %d"
                        ix line (line-number-at-pos (point)))
-            (aset has-amp-vec ix (f90-ts--indent-blank-leading-ampersand-line))
+            (aset vec ix (f90-ts--indent-blank-leading-amp-or-label-line))
             (forward-line 1)))
-      ;; return the vector of flags for restoring the ampersands
-      has-amp-vec)))
+      vec)))
 
 
-(defun f90-ts--indent-restore-leading-ampersand-region (beg has-amp-vec)
-  "Restore leading ampersands for lines starting at BEG according to HAS-AMP-VEC.
-HAS-AMP-VEC is a boolean vector as returned by
-`f90-ts--indent-blank-leading-ampersand-region'."
+(defun f90-ts--indent-restore-leading-amp-or-label-region (beg vec)
+  "Restore leading ampersands and statement labels from BEG using VEC.
+VEC is a vector as returned by
+`f90-ts--indent-blank-leading-amp-or-label-region'."
   (save-excursion
     (goto-char beg)
     (let ((line-beg (line-number-at-pos beg)))
-     (cl-loop
-      for line from line-beg
-      for has-amp across has-amp-vec
-      do (progn
-           (cl-assert (= (line-number-at-pos (point)) line)
-                      nil
-                      "f90-ts--indent-restore-leading-ampersand-region: line mismatch at index %d: expected line %d, got %d"
-                      (- line line-beg) line (line-number-at-pos (point)))
-           (when (or has-amp
-                     (and f90-ts-leading-ampersand
-                          (let ((node-first (f90-ts--first-node-on-line (point))))
-                            (f90-ts--node-type-p node-first "&"))))
-             (f90-ts--indent-restore-leading-ampersand-line))
-           (forward-line 1))))))
+      (cl-loop
+       for line from line-beg
+       for amp-or-label across vec
+       do (progn
+            (cl-assert (= (line-number-at-pos (point)) line)
+                       nil
+                       "line mismatch at index %d: expected %d, got %d"
+                       (- line line-beg) line (line-number-at-pos (point)))
+            (f90-ts--indent-restore-leading-amp-or-label-line amp-or-label)
+            (forward-line 1))))))
 
 
 (defun f90-ts--indent-line-aux (&optional variant)
@@ -4575,19 +4640,16 @@ removed before calling `treesit-indent' and then restored at the
 column determined by `f90-ts-leading-ampersand-style'."
   (let ((f90-ts--align-continued-variant-tab
          (or variant f90-ts-indent-list-line))
-        (has-amp (f90-ts--indent-blank-leading-ampersand-line)))
-    ;; do indentation without leading ampersand
+        (amp-or-label (f90-ts--indent-blank-leading-amp-or-label-line)))
+    ;; do indentation without leading ampersand and statement label
     (treesit-indent)
-    ;; where applicable insert leading ampersand if there was already
-    ;; one or if f90-ts-leading-ampersand is non-nil
+    ;; where applicable insert statement label or leading ampersand
+    ;; (ampersand if there was already one or if f90-ts-leading-ampersand
+    ;; is non-nil)
     (save-excursion
-      (when (or has-amp
-                (and f90-ts-leading-ampersand
-                     (let ((node-first (f90-ts--first-node-on-line (point))))
-                       (f90-ts--node-type-p node-first "&"))))
-        (f90-ts--indent-restore-leading-ampersand-line)))
+      (f90-ts--indent-restore-leading-amp-or-label-line amp-or-label))
     ;; if at beginning of line and ampersand after point, we need to skip to
-    ;; indentation after save-excursion (whose marker does not help here)
+    ;; indentation after save-excursion
     (skip-chars-forward "& \t")))
 
 
@@ -4614,9 +4676,9 @@ changed)."
                    (goto-char end)
                    (line-end-position))))
     (let ((old-text (buffer-substring-no-properties beg-reg end-reg))
-          (has-amp-vec (f90-ts--indent-blank-leading-ampersand-region beg-reg end-reg)))
+          (vec (f90-ts--indent-blank-leading-amp-or-label-region beg-reg end-reg)))
       (treesit-indent-region beg-reg end-reg)
-      (f90-ts--indent-restore-leading-ampersand-region beg-reg has-amp-vec)
+      (f90-ts--indent-restore-leading-amp-or-label-region beg-reg vec)
       ;; place point properly on last line, but where does treesit-indent-region and
       ;; the restore function (which uses a save-excursion) put point?
       (skip-chars-forward "& \t")
@@ -4638,14 +4700,14 @@ completion for a region, like indent-stmt operations on an end struct line."
           (f90-ts--with-check-modified-region beg-marker end-marker
             (f90-ts-complete-smart-end-region beg-marker end-marker)
             ;; remove leading ampersands, saving which lines had them
-            (let ((has-amp-vec (f90-ts--indent-blank-leading-ampersand-region
-                                beg-marker end-marker)))
+            (let ((vec (f90-ts--indent-blank-leading-amp-or-label-region
+                        beg-marker end-marker)))
               (treesit-indent-region beg-marker end-marker)
-              ;; Restore ampersands.  beg-marker still points to the
+              ;; restore ampersands or labels: beg-marker still points to the
               ;; first line (insertion-type nil keeps it before any text
               ;; treesit-indent may have inserted at the start).
-              (f90-ts--indent-restore-leading-ampersand-region
-               beg-marker has-amp-vec))))
+              (f90-ts--indent-restore-leading-amp-or-label-region
+               beg-marker vec))))
       (when beg-marker (set-marker beg-marker nil))
       (when end-marker (set-marker end-marker nil)))))
 

--- a/test/f90-ts-mode-test.el
+++ b/test/f90-ts-mode-test.el
@@ -145,6 +145,7 @@ without final newline."
     (f90-ts-smart-end . no-message)
     (f90-ts-leading-ampersand . nil)
     (f90-ts-leading-ampersand-style . (indent . 3))
+    (f90-ts-stmt-label-column . (left . 0))
     (f90-ts-special-comment-rules . ,f90-ts-mode-test--special-comment-rules)
     (f90-ts-comment-prefix-regexp . "!\\S-*\\(\\s-+\\|$\\)")
     (f90-ts-openmp-prefix-regexp . "!\\$\\(?:omp\\)?\\(\\s-+\\|$\\)")
@@ -879,7 +880,8 @@ If buffer was modified, insert `**' otherwise insert '--'."
    "indent_region_constructs.erts"
    "indent_region_select.erts"
    "indent_region_preproc.erts"
-   "indent_region_openmp.erts")
+   "indent_region_openmp.erts"
+   "indent_region_stmt_label.erts")
  '(nil ; no modification
    f90-ts-mode-test--remove-indent
    f90-ts-mode-test--add-indent)
@@ -943,10 +945,8 @@ If buffer was modified, insert `**' otherwise insert '--'."
  '(f90-ts-mode-test--indent-by-region
    f90-ts-mode-test--indent-by-line))
 
-;; expensive test variant of tests already registered
-;; with indent-by-region action;
-;; note that indent-by-line requires reparsing of the treesitter AST
-;; after each line, which is very expensive
+;; more expensive test variant of tests already registered
+;; with indent-by-region action
 (f90-ts-mode-test--prep-act-register
  "f90-ts-mode-test-extra"
  '("indent_region_progmod.erts"
@@ -954,7 +954,8 @@ If buffer was modified, insert `**' otherwise insert '--'."
    "indent_region_interface.erts"
    "indent_region_constructs.erts"
    "indent_region_select.erts"
-   "indent_region_preproc.erts")
+   "indent_region_preproc.erts"
+   "indent_region_stmt_label.erts")
  '(nil ; no modification
    f90-ts-mode-test--remove-indent
    f90-ts-mode-test--add-indent)
@@ -985,6 +986,7 @@ If buffer was modified, insert `**' otherwise insert '--'."
    "font_lock_forall.f90"
    "font_lock_openmp.f90"
    "font_lock_coarray.f90"
+   "font_lock_value.f90"
    "font_lock_special_var.f90"))
 
 

--- a/test/resources/font_lock_value.f90
+++ b/test/resources/font_lock_value.f90
@@ -1,0 +1,55 @@
+ subroutine values()
+!^^^^^^^^^^ font-lock-keyword-face
+!           ^^^^^^ font-lock-function-name-face
+!                 ^^ f90-ts-font-lock-bracket-face
+      x = 5
+!     ^ nil
+!       ^ f90-ts-font-lock-operator-face
+!         ^ font-lock-number-face
+      z = (6.0, 5.0) + (2e4_dp, -3e2_dp)
+!     ^ nil
+!       ^ f90-ts-font-lock-operator-face
+!         ^^^^^^^^^^ font-lock-number-face
+!                    ^ f90-ts-font-lock-operator-face
+!                      ^^^^^^^^^^^^^^^^^ font-lock-number-face
+      s = "abc"
+!     ^ nil
+!       ^ f90-ts-font-lock-operator-face
+!         ^^^^^ font-lock-string-face
+      l = .true. .or. .false.
+!     ^ nil
+!       ^ f90-ts-font-lock-operator-face
+!         ^^^^^^ font-lock-constant-face
+!                ^^^^ f90-ts-font-lock-operator-face
+!                     ^^^^^^^ font-lock-constant-face
+      p => null()
+!     ^ nil
+!       ^^ f90-ts-font-lock-delimiter-face
+!          ^^^^^^ font-lock-constant-face
+ 1234 stmt_label='here'
+!^^^^ font-lock-constant-face
+!     ^^^^^^^^^^ nil
+!               ^ f90-ts-font-lock-operator-face
+!                ^^^^^^ font-lock-string-face
+ end subroutine values
+!^^^ font-lock-keyword-face
+!    ^^^^^^^^^^ font-lock-keyword-face
+!               ^^^^^^ font-lock-function-name-face
+
+ #define x
+!^^^^^^^ font-lock-preprocessor-face
+!        ^ font-lock-constant-face
+ #ifdef x
+!^^^^^^ font-lock-preprocessor-face
+!       ^ font-lock-constant-face
+ #elifdef x
+!^^^^^^^^ font-lock-preprocessor-face
+!         ^ font-lock-constant-face
+ #endif
+!^^^^^^ font-lock-preprocessor-face
+
+ #ifndef x
+!^^^^^^^ font-lock-preprocessor-face
+!        ^ font-lock-constant-face
+ #endif
+!^^^^^^ font-lock-preprocessor-face

--- a/test/resources/indent_region_stmt_label.erts
+++ b/test/resources/indent_region_stmt_label.erts
@@ -1,0 +1,92 @@
+Point-Char: |
+
+No-Before-Newline
+No-After-Newline
+
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (when f90-ts-mode-test--prepare-fn
+      (funcall f90-ts-mode-test--prepare-fn))
+    (let ((f90-ts-stmt-label-column '(left . 0)))
+      (funcall f90-ts-mode-test--action-fn)))
+
+Name: stmt label left 1
+=-=
+subroutine sub()
+     read(file_unit, 1, err=200) x, y, z
+     return
+1    format(3F12.5)
+200  print 30000, "error"
+     error stop
+3000 format(2x,a10)
+30000 format(2x,a10)
+end subroutine sub
+=-=-=
+
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (when f90-ts-mode-test--prepare-fn
+      (funcall f90-ts-mode-test--prepare-fn))
+    (let ((f90-ts-stmt-label-column '(left . 3)))
+      (funcall f90-ts-mode-test--action-fn)))
+
+Name: stmt label left 2
+=-=
+subroutine sub()
+     read(file_unit, 1, err=200) x, y, z
+     return
+   1 format(3F12.5)
+   200 print 30000, "error"
+     error stop
+   3000 format(2x,a10)
+   30000 format(2x,a10)
+   99999 end subroutine sub
+=-=-=
+
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (when f90-ts-mode-test--prepare-fn
+      (funcall f90-ts-mode-test--prepare-fn))
+    (let ((f90-ts-stmt-label-column '(right . 4)))
+      (funcall f90-ts-mode-test--action-fn)))
+
+Name: stmt label right 1
+=-=
+subroutine sub()
+     read(file_unit, 1, err=200) x, y, z
+     return
+    1 format(3F12.5)
+  200 print 30000, "error"
+     error stop
+ 3000 format(2x,a10)
+30000 format(2x,a10)
+end subroutine sub
+=-=-=
+
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (when f90-ts-mode-test--prepare-fn
+      (funcall f90-ts-mode-test--prepare-fn))
+    (let ((f90-ts-stmt-label-column '(right . 4))
+          (f90-ts-indent-toplevel 6))
+      (funcall f90-ts-mode-test--action-fn)))
+
+Name: stmt label right 2
+=-=
+module mod
+contains
+      subroutine sub()
+           read(file_unit, 1, err=200) x, y, z
+           return
+    1      format(3F12.5)
+  200      print 30000, "error"
+           error stop
+ 3000      format(2x,a10)
+30000      format(2x,a10)
+      end subroutine sub
+end module mod
+=-=-=


### PR DESCRIPTION
Add indentation handling for statement labels and a rule for syntax highlighting. Statement labels are handled very similar to leading ampersands in continued lines. Hence existing function have been extended and complemented to deal with statement labels as well. Like leading ampersand, labels are removed, code is indented and then saved labels are reinserted, preserving the computed indentation as best as possible.
