### PR TITLE
Fix some cases of break line operation for point close to end of line

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -36,12 +36,13 @@ for implementation.
     - [Joining lines](#joining-lines)
   - [Comment region](#comment-region)
   - [Mark regions based on tree-sitter nodes](#mark-regions-based-on-tree-sitter-nodes)
-- [Testing with ERT](#testing-with-ert)
-  - [Makefile](#makefile)
-  - [Indentation tests](#indentation-tests)
-  - [Font lock tests](#font-lock-tests)
-  - [Custom tests](#custom-tests)
-- [Logging and debugging](#logging-and-debugging)
+- [Development and Testing](#development-and-testing)
+  - [Logging](#logging)
+  - [Testing with ERT](#testing-with-ert)
+    - [Makefile](#makefile)
+    - [Indentation tests](#indentation-tests)
+    - [Font lock tests](#font-lock-tests)
+    - [Custom tests](#custom-tests)
 
 
 
@@ -629,59 +630,12 @@ Key bindings are provided in the transient popup (`C-c C-f`) under the Region se
 | `f90-ts-next-region`             | `]`       | Move selected region to next sibling                                     |
 
 
-## Testing with ERT
+## Development and Testing
 
-The mode comes with a number of tests in `test/resources`.
-Registering and running tests is done in `test/f90-ts-mode-test.el`
+In the `test` folder, two modules for testing and logging during development are provided.
+Tests are located in `test/resources`.
 
-Standard tests are named `f90-ts-mode-test-std--...`, whereas additional tests start with `f90-ts-mode-test-extra--...`.
-Registering of tests is done semi-automatic in `f90-ts-mode-test-indent-register`, `f90-ts-mode-test-font-lock-register`
-and other functions in `f90-ts-mode-test.el`.
-
-Tests are run with a prescribed set of custom variables. In particular, indentation values are chosen
-all differently, such that errors can be spotted more easily. Within erts files, custom variable can
-and sometimes are overwritten to allow testing various aspects of the mode.
-
-
-### Makefile
-
-There is a Makefile for running various tests. Relevant targets are:
-* test-checkdoc
-* test-byte-compile
-* test-ert-std
-* test-ert-extra
-* test-ert-all
-* test-ert-parallel (use with `make -j<N> test-ert-parallel` to run all ert tests in parallel)
-
-
-### Indentation tests
-
-Indentation tests are in erts file format. For indentation of an after part between `=-=` and `=-=-=`,
-function `f90-ts-mode-test-update-erts-after` can be used (first remove point char `|` if present) to
-help setting up a new test. Indentation tests have prep-fn preparation function (like remove indentation)
-and an action function (like indent-region, indent-line all/single line).
-The erts files are used to check various combinations.
-
-
-### Font lock tests
-
-Font lock tests are in f90 files, with caret assertion notation. This notation can be automatically
-generated for new files or updated by `f90-ts-mode-test-update-face-annotations`.
-The code is automatically indented by 1, as assertion lines start with a !, so that all faces
-including those which would be at column 0 can be checked properly.
-The generated annotations are exhaustive, including nil annotations to assert that part of the code
-is not highlighted.
-
-Note: fortran test code should NOT use the caret `^`, even in comments, as the ert parser gets confused.
-
-
-### Other tests
-
-There are a number of other tests, like tests for region and navigation operations, or with custom
-action blocks for testing specific aspects not easily covered by the whole-buffer operations.
-
-
-## Logging and debugging
+### Logging
 
 The following logging functions are provided by `test/f90-ts-log.el`.
 
@@ -708,3 +662,63 @@ All logging and inspection functions write into a dedicated log buffer `*f90-ts-
 with its own minor mode to allow some dedicated keybindings.
 
 By default nothing is logged and the buffer is empty.
+
+
+### Testing with ERT
+
+The mode comes with a number of tests in `test/resources`.
+Registering and running tests is done in `test/f90-ts-mode-test.el`
+
+Standard tests are named `f90-ts-mode-test-std--...`, whereas additional tests start with `f90-ts-mode-test-extra--...`.
+Registering of tests is done semi-automatic in `f90-ts-mode-test-indent-register`, `f90-ts-mode-test-font-lock-register`
+and other functions in `f90-ts-mode-test.el`.
+
+Tests are run with a prescribed set of custom variables. In particular, indentation values are chosen
+all differently, such that errors can be spotted more easily. Within erts files, custom variable can
+and sometimes are overwritten to allow testing various aspects of the mode.
+
+
+#### Makefile
+
+There is a Makefile for running various tests. Relevant targets are:
+* test-checkdoc
+* test-byte-compile
+* test-ert-std
+* test-ert-extra
+* test-ert-all
+* test-ert-parallel (use with `make -j<N> test-ert-parallel` to run all ert tests in parallel)
+
+During development if functions from `f90-ts-log.el` are used, testing fails as the log package
+is not loaded (see [Logging](#logging)). To avoid this and suppress logging, the make command should be invoked by
+```bash
+make test-target-name DEV=1
+```
+which turns the log functions into no-op operations.
+
+
+
+#### Indentation tests
+
+Indentation tests are in erts file format. For indentation of an after part between `=-=` and `=-=-=`,
+function `f90-ts-mode-test-update-erts-after` can be used (first remove point char `|` if present) to
+help setting up a new test. Indentation tests have prep-fn preparation function (like remove indentation)
+and an action function (like indent-region, indent-line all/single line).
+The erts files are used to check various combinations.
+
+
+#### Font lock tests
+
+Font lock tests are in f90 files, with caret assertion notation. This notation can be automatically
+generated for new files or updated by `f90-ts-mode-test-update-face-annotations`.
+The code is automatically indented by 1, as assertion lines start with a !, so that all faces
+including those which would be at column 0 can be checked properly.
+The generated annotations are exhaustive, including nil annotations to assert that part of the code
+is not highlighted.
+
+Note: fortran test code should NOT use the caret `^`, even in comments, as the ert parser gets confused.
+
+
+#### Other tests
+
+There are a number of other tests, like tests for region and navigation operations, or with custom
+action blocks for testing specific aspects not easily covered by the whole-buffer operations.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 EMACS ?= emacs
 EMACSFLAGS = -batch -Q -L .
 
+# to allow log instructions (as no-ops) run with: make test-target-name DEV=1
+ifdef DEV
+EMACSFLAGS += --eval "(setq f90-ts-allow-log t)"
+endif
+
 LOAD = \
 	--eval "(setq debug-on-error t)" \
 	--eval "(progn \

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -4688,10 +4688,7 @@ column determined by `f90-ts-leading-ampersand-style'."
     ;; (ampersand if there was already one or if f90-ts-leading-ampersand
     ;; is non-nil)
     (save-excursion
-      (f90-ts--indent-restore-leading-amp-or-label-line amp-or-label))
-    ;; if at beginning of line and ampersand after point, we need to skip to
-    ;; indentation after save-excursion
-    (skip-chars-forward "& \t")))
+      (f90-ts--indent-restore-leading-amp-or-label-line amp-or-label))))
 
 
 (defun f90-ts--indent-and-complete-line-aux (variant indent-struct)

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -4543,13 +4543,17 @@ blanked."
         (cond
          ;; leading ampersand
          ((and c (eq c ?&))
-          (let ((node (treesit-node-at (point))))
-            (when (and node
-                       (= (point) (treesit-node-start node))
-                       (f90-ts--node-type-p node "&"))
-              (delete-char 1)
-              (insert " ")
-              '(amp))))
+          ;; if this line contains a single ampersand and optionally some comment,
+          ;; then we should considers this to be a trailing ampersand and keep it as is
+          (unless (looking-at  "&\\s-*\\(?:!\\|$\\)")
+            (let ((node (treesit-node-at (point))))
+              ;; this excludes string literals
+              (when (and node
+                         (= (point) (treesit-node-start node))
+                         (f90-ts--node-type-p node "&"))
+                (delete-char 1)
+                (insert " ")
+                '(amp)))))
          ;; statement label
          ((and c (>= c ?0) (<= c ?9))
           (let ((node (treesit-node-at (point))))
@@ -4958,9 +4962,11 @@ The variant to be used can be customized.  Intended for use in key bindings."
 
    (t
     (delete-horizontal-space)
+    ;; note that a leading ampersand (depend on f90-ts-leading-ampersand)
+    ;; is inserted by the indentation function, and thus does not need to
+    ;; be added here
     (f90-ts--break-line-insert-amp-at-end)
-    (newline 1)
-    (if f90-ts-leading-ampersand (insert "&"))))
+    (newline 1)))
   ;; finally indent the new line after insertion of the newline
   (indent-according-to-mode))
 

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -824,6 +824,13 @@ implementation when `f90-ts-log' is loaded."
   (error "Function f90-ts-log-msg not available: load f90-ts-log.el first"))
 
 
+(defun f90-ts-log-line (_category _msg &optional _pos)
+  "Logging stub.
+Load f90-ts-log.el to enable.  This function is replaced by the real
+implementation when `f90-ts-log' is loaded."
+  (error "Function f90-ts-log-line not available: load f90-ts-log.el first"))
+
+
 (defun f90-ts-log-inspect-node (_category _node _info)
   "Node inspection stub.
 Load f90-ts-log.el to enable.  This function is replaced by the real
@@ -4621,8 +4628,7 @@ Returns a vector (one entry per line) of values as returned by
        do (progn
             (cl-assert (= (line-number-at-pos (point)) line)
                        nil
-                       "f90-ts--indent-blank-leading-amp-or-label-region: \
-line mismatch at index %d: expected %d, got %d"
+                       "line mismatch at index %d: expected %d, got %d"
                        ix line (line-number-at-pos (point)))
             (aset vec ix (f90-ts--indent-blank-leading-amp-or-label-line))
             (forward-line 1)))

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -819,30 +819,46 @@ siblings with the correct parent.  So walking is just one step in general."
 
 (defun f90-ts-log-msg (_category _fmt &rest _args)
   "Logging stub.
-Load f90-ts-log.el to enable.  This function is replaced by the real
-implementation when `f90-ts-log' is loaded."
-  (error "Function f90-ts-log-msg not available: load f90-ts-log.el first"))
+Load f90-ts-log.el to enable logging.  This function is replaced by the real
+implementation when the logging package is loaded.
+
+Set `f90-ts-allow-log' to allow log instruction as no-op without `f90-ts-log'.
+This is used by the Makefile to run ert tests during development."
+  (unless (bound-and-true-p f90-ts-allow-log)
+  (error "Function f90-ts-log-msg not available: load f90-ts-log.el first")))
 
 
 (defun f90-ts-log-line (_category _msg &optional _pos)
   "Logging stub.
-Load f90-ts-log.el to enable.  This function is replaced by the real
-implementation when `f90-ts-log' is loaded."
-  (error "Function f90-ts-log-line not available: load f90-ts-log.el first"))
+Load f90-ts-log.el to enable logging.  This function is replaced by the real
+implementation when the logging package is loaded.
+
+Set `f90-ts-allow-log' to allow log instruction as no-op without `f90-ts-log'.
+This is used by the Makefile to run ert tests during development."
+  (unless (bound-and-true-p f90-ts-allow-log)
+    (error "Function f90-ts-log-line not available: load f90-ts-log.el first")))
 
 
 (defun f90-ts-log-inspect-node (_category _node _info)
   "Node inspection stub.
-Load f90-ts-log.el to enable.  This function is replaced by the real
-implementation when `f90-ts-log' is loaded."
-  (error "Function f90-ts-log-inspect-node not available: load f90-ts-log.el first"))
+Load f90-ts-log.el to enable logging.  This function is replaced by the real
+implementation when the logging package is loaded.
+
+Set `f90-ts-allow-log' to allow log instruction as no-op without `f90-ts-log'.
+This is used by the Makefile to run ert tests during development."
+  (unless (bound-and-true-p f90-ts-allow-log)
+    (error "Function f90-ts-log-inspect-node not available: load f90-ts-log.el first")))
 
 
 (defun f90-ts-log-indent-print-state (_msg)
   "Debug indent rule stub.
-Load f90-ts-log.el to enable.  This function is replaced by the real
-implementation when `f90-ts-log' is loaded."
-  (error "Function f90-ts-log-indent-print-state not available: load f90-ts-log.el first"))
+Load f90-ts-log.el to enable logging.  This function is replaced by the real
+implementation when the logging package is loaded.
+
+Set `f90-ts-allow-log' to allow log instruction as no-op without `f90-ts-log'.
+This is used by the Makefile to run ert tests during development."
+  (unless (bound-and-true-p f90-ts-allow-log)
+    (error "Function f90-ts-log-indent-print-state not available: load f90-ts-log.el first")))
 
 
 ;;;-----------------------------------------------------------------------------

--- a/test/f90-ts-log.el
+++ b/test/f90-ts-log.el
@@ -117,6 +117,20 @@ by CATEGORY and a time stamp."
 
 
 ;;;-----------------------------------------------------------------------------
+
+(defun f90-ts-log-line (category msg &optional pos)
+  "Write the line at POS or point to the log buffer.
+Use CATEGORY and MSG to prefix the log message."
+  (let ((p (or pos (point))))
+  (save-excursion
+    (goto-char p)
+    (let ((line (buffer-substring-no-properties (line-beginning-position)
+                                                (line-end-position))))
+      (f90-ts-log-msg category "%s: line at <pos:%d,line:%d> = %S"
+                      msg p (line-number-at-pos p) line)))))
+
+
+;;;-----------------------------------------------------------------------------
 ;; node inspection
 
 (defun f90-ts-log--treesit-inspect-node (node-inspect)

--- a/test/resources/break_line.erts
+++ b/test/resources/break_line.erts
@@ -228,6 +228,6 @@ end subroutine sub_3
 subroutine sub_3()
      ! invalid code
      x = &
-&           ! number still to add
+            ! number still to add
 end subroutine sub_3
 =-=-=

--- a/test/resources/indent_line_empty.erts
+++ b/test/resources/indent_line_empty.erts
@@ -71,6 +71,45 @@ subroutine sub()
 end subroutine sub
 =-=-=
 
+Name: empty continued line 2
+=-=
+! position point before final ampersand
+! not valid code, but happens during typing
+subroutine sub()
+   x123456 = 6 + &
+|            &
+             5
+end subroutine sub
+=-=
+! position point before final ampersand
+! not valid code, but happens during typing
+subroutine sub()
+   x123456 = 6 + &
+      &      |&
+             5
+end subroutine sub
+=-=-=
+
+
+Name: empty continued line 3
+=-=
+! position point before final ampersand
+! not valid code, but happens during typing
+subroutine sub()
+   x123456 = 6 + &
+|            &   ! comment
+             5
+end subroutine sub
+=-=
+! position point before final ampersand
+! not valid code, but happens during typing
+subroutine sub()
+   x123456 = 6 + &
+      &      |&   ! comment
+             5
+end subroutine sub
+=-=-=
+
 Code:
   (lambda ()
     (f90-ts-mode)
@@ -80,6 +119,44 @@ Code:
       (funcall f90-ts-mode-test--action-fn)))
 
 Name: empty continued line 4
+=-=
+! position point before final ampersand
+! not valid code, but happens during typing
+subroutine sub()
+   x123456 = 6 + &
+|            &   ! comment
+             5
+end subroutine sub
+=-=
+! position point before final ampersand
+! not valid code, but happens during typing
+subroutine sub()
+   x123456 = 6 + &
+             |&   ! comment
+             5
+end subroutine sub
+=-=-=
+
+Name: empty continued line 5
+=-=
+! position point before final ampersand
+! not valid code, but happens during typing
+subroutine sub()
+   x123456 = 6 + &
+|      &      &
+             5
+end subroutine sub
+=-=
+! position point before final ampersand
+! not valid code, but happens during typing
+subroutine sub()
+   x123456 = 6 + &
+      &      |&
+             5
+end subroutine sub
+=-=-=
+
+Name: empty continued line 6
 =-=
 ! position point before final ampersand
 ! not valid code, but happens during typing

--- a/test/resources/indent_line_empty.erts
+++ b/test/resources/indent_line_empty.erts
@@ -43,3 +43,57 @@ subroutine empty2()
      (arg1, arg2) + arg3)
 end subroutine empty2
 =-=-=
+
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (let ((f90-ts-leading-ampersand t))
+      (when f90-ts-mode-test--prepare-fn
+        (funcall f90-ts-mode-test--prepare-fn))
+      (funcall f90-ts-mode-test--action-fn)))
+
+Name: empty continued line 1
+=-=
+! position point before final ampersand
+! not valid code, but happens during typing
+subroutine sub()
+   x123456 = 6 + &
+|      &      &
+             5
+end subroutine sub
+=-=
+! position point before final ampersand
+! not valid code, but happens during typing
+subroutine sub()
+   x123456 = 6 + &
+      &      |&
+             5
+end subroutine sub
+=-=-=
+
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (let ((f90-ts-leading-ampersand nil))
+      (when f90-ts-mode-test--prepare-fn
+        (funcall f90-ts-mode-test--prepare-fn))
+      (funcall f90-ts-mode-test--action-fn)))
+
+Name: empty continued line 4
+=-=
+! position point before final ampersand
+! not valid code, but happens during typing
+subroutine sub()
+   x123456 = 6 + &
+|      &      &
+             5
+end subroutine sub
+=-=
+! position point before final ampersand
+! not valid code, but happens during typing
+subroutine sub()
+   x123456 = 6 + &
+      &      |&
+             5
+end subroutine sub
+=-=-=

--- a/test/todo/parse_tree.f90
+++ b/test/todo/parse_tree.f90
@@ -36,3 +36,16 @@ subroutine sub()
       call other()
    end if
 end subroutine sub
+
+! tree for the assignment line:
+! (assignment_statement left: (identifier) =
+!   right: (math_expression left: (number_literal) operator: + & & right: (number_literal)))
+! should we rather generate four ampersand & & & &, two of which are virtual?
+! that would match the tree with leading ampersands and would be more consistent,
+! this would also help with correct indentation of the line containing 5 (which has no leading ampersand)
+! note: this is not valid code, but might easily occur during typing
+subroutine sub()
+   x123456 = 6 + &
+            &
+             5
+end subroutine sub


### PR DESCRIPTION
Fix some cases of break line operation for point close to end of line.
This fixes issue #93.

This also adds another logging function to probe into current state of a line during transformational operations.