### PR TITLE
Handle comment blocks in mark region operations

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -142,7 +142,7 @@ placed somewhere in `init.el` (or elsewhere).
          ("A-<backspace>" . #'f90-ts-join-line-prev)
          ("A-<delete>"    . #'f90-ts-join-line-next)
          ("A-\\"          . #'f90-ts-enlarge-region)
-         ("A-0"           . #'f90-ts-child0-region)
+         ("A-0"           . #'f90-ts-shrink-region-child0)
          ("A-["           . #'f90-ts-prev-region)
          ("A-]"           . #'f90-ts-next-region)))
 ```
@@ -178,7 +178,7 @@ First clone the repository of `f90-ts-mode` as mentioned above.
          ("A-<backspace>" . #'f90-ts-join-line-prev)
          ("A-<delete>"    . #'f90-ts-join-line-next)
          ("A-\\"          . #'f90-ts-enlarge-region)
-         ("A-0"           . #'f90-ts-child0-region)
+         ("A-0"           . #'f90-ts-shrink-region-child0)
          ("A-["           . #'f90-ts-prev-region)
          ("A-]"           . #'f90-ts-next-region)))
 ```
@@ -614,12 +614,12 @@ comment region operations.
 
 Key bindings are provided in the transient popup (`C-c C-f`) under the Region section:
 
-| Function                         | Popup key | Description                                                              |
-|----------------------------------|-----------|--------------------------------------------------------------------------|
-| `f90-ts-enlarge-region`          | `r`       | Find smallest parent node of existing region which is strictly larger    |
-| `f90-ts-child0-region`           | `0`       | Reduce existing region to a first (grand)child which is strictly smaller |
-| `f90-ts-prev-region`             | `[`       | Move selected region to previous sibling                                 |
-| `f90-ts-next-region`             | `]`       | Move selected region to next sibling                                     |
+| Function                      | Popup key | Description                                                              |
+|-------------------------------|-----------|--------------------------------------------------------------------------|
+| `f90-ts-enlarge-region`       | `r`       | Find smallest parent node of existing region which is strictly larger    |
+| `f90-ts-shrink-region-child0` | `0`       | Shrink region to a first (grand)child which is strictly smaller          |
+| `f90-ts-prev-region`          | `[`       | Move selected region to previous sibling                                 |
+| `f90-ts-next-region`          | `]`       | Move selected region to next sibling                                     |
 
 
 ## Development and Testing

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -607,6 +607,11 @@ any blanks to keep original indentation of commented code.
 ### Mark region based on tree-sitter nodes
 
 Regions can be selected, enlarged, shrunk or moved based on tree-sitter nodes.
+Blocks of comments with the same comment prefix are identified and dealt with like
+the block would be represented by a node (which they are not).
+This is particularly useful in conjunction with comment prefixes and
+comment region operations.
+
 Key bindings are provided in the transient popup (`C-c C-f`) under the Region section:
 
 | Function                         | Popup key | Description                                                              |

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ It will automatically be loaded when opening a file with extension `.f90`.
          ("A-<backspace>" . #'f90-ts-join-line-prev)
          ("A-<delete>"    . #'f90-ts-join-line-next)
          ("A-\\"          . #'f90-ts-enlarge-region)
-         ("A-0"           . #'f90-ts-child0-region)
+         ("A-0"           . #'f90-ts-shrink-region-child0)
          ("A-["           . #'f90-ts-prev-region)
          ("A-]"           . #'f90-ts-next-region)))
 ```

--- a/README.md
+++ b/README.md
@@ -132,6 +132,4 @@ The following list provides features planned for implementation (somewhat ordere
 - Enlarge and shrink region operations:
    * Handle comment regions with same prefix as virtual nodes. This helps with comment region operations.
    * Add other child selection options (select last child, search child, etc.)
-- `undo-boundary` to group internal changes to blocks of changes for undo.
-  This mainly concerns complex indentation operations (like indentation of statements or region).
 - Electric insert similar to `f90-electric-insert`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Tree-sitter based major mode for editing Fortran (Fortran 90 / 2003 and
 newer) in free source form in Emacs. It requires Emacs 30+.
 The mode is inspired by f90-mode in emacs core.
 
-This project is under active development, see [Roadmap](#roadmap)
+This project is under active [development](#roadmap).
 For a comprehensive overview see [MANUAL.md](MANUAL.md).
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -130,6 +130,5 @@ The following list provides features planned for implementation (somewhat ordere
 - More list contexts. There is a number of list like contexts, which are not yet supported,
   but for which proper alignment would be nice.
 - Enlarge and shrink region operations:
-   * Handle comment regions with same prefix as virtual nodes. This helps with comment region operations.
    * Add other child selection options (select last child, search child, etc.)
 - Electric insert similar to `f90-electric-insert`.

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -677,7 +677,7 @@ seem to make much sense."
 
 ;; ;; region
 ;; (define-key f90-ts-prefix-map (kbd "r") #'f90-ts-enlarge-region)
-;; (define-key f90-ts-prefix-map (kbd "0") #'f90-ts-child0-region)
+;; (define-key f90-ts-prefix-map (kbd "0") #'f90-ts-shrink-region-child0)
 ;; (define-key f90-ts-prefix-map (kbd "[") #'f90-ts-prev-region)
 ;; (define-key f90-ts-prefix-map (kbd "]") #'f90-ts-next-region)
 
@@ -729,7 +729,7 @@ seem to make much sense."
     ("C"   "Comment region (custom)"           f90-ts-comment-region-custom)]
    ["Region"
     ("r"   "Enlarge region"                    f90-ts-enlarge-region)
-    ("0"   "Child-0 region"                    f90-ts-child0-region)
+    ("0"   "Child-0 region"                    f90-ts-shrink-region-child0)
     ("["   "Previous region"                   f90-ts-prev-region)
     ("]"   "Next region"                       f90-ts-next-region)]]
   [["Procedure navigation"
@@ -5477,7 +5477,7 @@ The comment prefix is matched by `f90-ts-openmp-prefix-regexp' and
     (f90-ts-enlarge-region-initial)))
 
 
-(defun f90-ts-child0-region ()
+(defun f90-ts-shrink-region-child0 ()
   "Find smallest node covering region.
 Then reduce region to its first child.  If there are further first child with
 same region, return the smallest of these grandchildren."
@@ -6586,10 +6586,10 @@ and keyword are sometimes equal.  But we only want the structure node."
      ["Comment/uncomment region (default prefix)" f90-ts-comment-region-default :active (region-active-p)]
      ["Comment/uncomment region (custom prefix)"  f90-ts-comment-region-custom  :active (region-active-p)])
     ("Region"
-     ["Enlarge region"  f90-ts-enlarge-region :active t]
-     ["Child-0 region"  f90-ts-child0-region  :active (region-active-p)]
-     ["Previous region" f90-ts-prev-region    :active (region-active-p)]
-     ["Next region"     f90-ts-next-region    :active (region-active-p)])
+     ["Enlarge region"          f90-ts-enlarge-region       :active t]
+     ["Shrink region [child-0]" f90-ts-shrink-region-child0 :active (region-active-p)]
+     ["Previous region"         f90-ts-prev-region          :active (region-active-p)]
+     ["Next region"             f90-ts-next-region          :active (region-active-p)])
     "---"
     ("Defun & Thing"
      ["Beginning of defun" beginning-of-defun :active t]

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -889,6 +889,18 @@ is matched by TYPE-RX."
              (string-match-p type-rx type-n)))))
 
 
+(defun f90-ts--node-same-span-p (node1 node2)
+  "Return non-nil if NODE1 and NODE2 have the same span."
+  (and (= (treesit-node-start node1) (treesit-node-start node2))
+       (= (treesit-node-end node1)   (treesit-node-end node2))))
+
+
+(defun f90-ts--node-has-span-p (node beg end)
+  "Return non-nil if NODE has the span BEG..END."
+  (and (= beg (treesit-node-start node))
+       (= end (treesit-node-end node))))
+
+
 (defun f90-ts--comment-prefix (node)
   "Extract the starting character sequence from a comment NODE.
 NODE is assumed to be of type comment.  It uses `f90-ts-openmp-prefix-regexp'
@@ -2491,7 +2503,10 @@ otherwise return column as is."
         ;;(f90-ts-log-msg :cachecol "line, entry, delta = %s, %s, %s" line entry delta)
         ;;(f90-ts-log-msg :cachecol "bol col, current = %s, %s" bol-col bol-current)
 
-        (cl-assert entry nil "no entry for line in cache, line=%s, cache=%s" line f90-ts--continued-line-cache)
+        (cl-assert entry
+                   nil
+                   "no entry for line in cache, line=%s, cache=%s"
+                   line f90-ts--continued-line-cache)
         (if (= bol-col bol-current)
             ;; not yet flushed
             (+ col delta)
@@ -5255,18 +5270,23 @@ Otherwise return POS."
      (t             pos))))
 
 
+(defun f90-ts--mark-region (beg end &optional reversed)
+  "Mark region BEG..END.
+If REVERSED is non-nil, then mark region from END..BEG,
+which places point at start of region."
+  (push-mark beg t t)
+  (goto-char end)
+  (when reversed
+    (exchange-point-and-mark)))
+
+
 (defun f90-ts--mark-region-node (node &optional reversed)
   "Mark the region spanned by NODE.
 If REVERSED is non-nil, then put point at start of region, otherwise point
 is at end of region."
   (let ((beg (treesit-node-start node))
         (end (treesit-node-end node)))
-    (if reversed
-        (progn
-          (goto-char beg)
-          (push-mark end t t))
-      (push-mark beg t t)
-      (goto-char end))))
+    (f90-ts--mark-region beg end reversed)))
 
 
 (defun f90-ts--smallest-child0-same-span (node)
@@ -5274,8 +5294,7 @@ is at end of region."
   (cl-loop for current = node then child
            for child = (treesit-node-child current 0 t)
            while (and child
-                      (= (treesit-node-start child) (treesit-node-start current))
-                      (= (treesit-node-end child) (treesit-node-end current)))
+                      (f90-ts--node-same-span-p child current))
            finally return current))
 
 
@@ -5287,8 +5306,7 @@ same bounds, which is the contains_statement node."
   (treesit-parent-while
    node
    (lambda (n)
-     (and (= (treesit-node-start n) (treesit-node-start node))
-          (= (treesit-node-end n) (treesit-node-end node))))))
+     (f90-ts--node-same-span-p n node))))
 
 
 (defun f90-ts--smallest-named-node-containing-region (beg end)
@@ -5341,28 +5359,122 @@ Querying at POS-1 gives the expected answer."
     (car sorted)))
 
 
+(defun f90-ts--comment-block-extent (node)
+  "Return (FIRST . LAST) comment nodes for the block containing NODE.
+Comments are grouped by prefix as extracted by `f90-ts--comment-prefix'.
+NODE must be of type comment."
+  (cl-assert (f90-ts--node-type-p node "comment")
+             nil "comment node expected")
+  (let* ((prefix (f90-ts--comment-prefix node))
+         (same-p (lambda (n)
+                   (and (f90-ts--node-type-p n "comment")
+                        (equal (f90-ts--comment-prefix n)
+                               prefix))))
+
+         (first  (cl-loop
+                  for cur = node then next
+                  for next = (treesit-node-prev-sibling cur)
+                  while (and next (funcall same-p next))
+                  finally return cur))
+         (last   (cl-loop
+                  for cur = node then next
+                  for next = (treesit-node-next-sibling cur)
+                  while (and next (funcall same-p next))
+                  finally return cur)))
+    (cons first last)))
+
+
+(defun f90-ts--comment-block-region (beg end)
+  "Classify type of region BEG..END with respect to comment blocks.
+Returns a list:
+  ('single NODE)   region is exactly one comment node
+  ('block  FN LN)  region is exactly the full block from first node FN
+                   to last node LN
+  ('partial FN LN) region is within block but neither single nor full,
+                   whole block is starts and end with nodes FN and LN
+  nil              not within a uniform comment block"
+  (let* ((node-beg (treesit-node-at beg))
+         (node-end (treesit-node-at (max beg (1- end)))))
+    (when (and (f90-ts--node-type-p node-beg "comment")
+               (f90-ts--node-type-p node-end "comment")
+               (equal (f90-ts--comment-prefix node-beg)
+                      (f90-ts--comment-prefix node-end)))
+      (let* ((extent (f90-ts--comment-block-extent node-beg))
+             (node-first (car extent))
+             (node-last  (cdr extent))
+             (first-beg (treesit-node-start node-first))
+             (last-end  (treesit-node-end   node-last)))
+        (cond
+         ((and (= beg (treesit-node-start node-beg))
+               (= end (treesit-node-end   node-end))
+               (treesit-node-eq node-beg node-end))
+          (list 'single node-beg))
+
+         ((and (= beg first-beg) (= end last-end))
+          (list 'block node-first node-last))
+
+         (t
+          (list 'partial node-first node-last)))))))
+
+
+(defun f90-ts-enlarge-region-active ()
+  "Expand active region to next larger node."
+  (cl-assert (use-region-p)
+             nil
+             "active region required")
+
+  (let* ((beg (region-beginning))
+         (end (region-end))
+         (comment-kind (f90-ts--comment-block-region beg end)))
+    (cl-destructuring-bind (&optional ck reg-first _) comment-kind
+      (if (eq ck 'single)
+          ;; single comment line: expand to full block
+          (let* ((extent  (f90-ts--comment-block-extent reg-first))
+                 (ext-first   (car extent))
+                 (ext-last    (cdr extent)))
+            (if (treesit-node-eq ext-first ext-last)
+                ;; block is just one line, fall through to tree-sitter ascent
+                (if-let ((node (f90-ts--smallest-named-node-containing-region beg end)))
+                    (f90-ts--mark-region-node node f90-ts-mark-region-reversed)
+                  (message "no tree-sitter node found enlarging current region"))
+              (f90-ts--mark-region (treesit-node-start ext-first)
+                                   (treesit-node-end ext-last)
+                                   f90-ts-mark-region-reversed)))
+        (if-let ((node (f90-ts--smallest-named-node-containing-region beg end)))
+            (f90-ts--mark-region-node node f90-ts-mark-region-reversed)
+          (message "no tree-sitter node found enlarging current region"))))))
+
+
+(defun f90-ts-enlarge-region-initial ()
+  "Mark region of smallest named node at point.
+This operation assumes that no region is active."
+  (cl-assert (not (use-region-p))
+             nil
+             "active region already present")
+
+  (let* ((pos     (f90-ts--pos-nonspace (point)))
+         (node-at (treesit-node-at pos)))
+    (if (f90-ts--node-type-p node-at "comment")
+        (f90-ts--mark-region-node node-at f90-ts-mark-region-reversed)
+      (if-let* ((node-on (f90-ts--node-on-pos pos 'named))
+                (node    (f90-ts--largest-node-same-span node-on)))
+          (f90-ts--mark-region-node node f90-ts-mark-region-reversed)
+        (message "no tree-sitter node found at point")))))
+
+
 (defun f90-ts-enlarge-region ()
   "Expand region to next larger node.
 If no region is active, select the smallest named node at point.
 If region is active, expand to the smallest named node that is larger
-than current region."
+than current region.
+If current node is a comment belonging to a block of comments all
+starting with the same comment prefix enlarge to the block of comments.
+The comment prefix is matched by `f90-ts-openmp-prefix-regexp' and
+`f90-ts-comment-prefix-regexp'."
   (interactive)
   (if (use-region-p)
-      (let* ((beg (region-beginning))
-             (end (region-end))
-             (node (f90-ts--smallest-named-node-containing-region beg end)))
-        (if node
-            (f90-ts--mark-region-node node
-                                      f90-ts-mark-region-reversed)
-          (message "no tree-sitter node found enlarging current region")))
-    ;; no active region, select smallest named node at point
-    ;; (but move point to nonspace part first)
-    (if-let* ((pos (f90-ts--pos-nonspace (point)))
-              (node-on (f90-ts--node-on-pos pos 'named))
-              (node (f90-ts--largest-node-same-span node-on)))
-        (f90-ts--mark-region-node node
-                                  f90-ts-mark-region-reversed)
-      (message "no tree-sitter node found at point"))))
+      (f90-ts-enlarge-region-active)
+    (f90-ts-enlarge-region-initial)))
 
 
 (defun f90-ts-child0-region ()
@@ -5371,14 +5483,18 @@ Then reduce region to its first child.  If there are further first child with
 same region, return the smallest of these grandchildren."
   (interactive)
   (if (use-region-p)
-      (if-let* ((beg (region-beginning))
-                (end (region-end))
-                (node-on (treesit-node-on beg end))
-                (node (f90-ts--smallest-child0-same-span node-on))
-                (child0 (treesit-node-child node 0 t)))
-          (f90-ts--mark-region-node child0
-                                    f90-ts-mark-region-reversed)
-        (message "no tree-sitter child0 found for current region"))
+      (let* ((beg (region-beginning))
+             (end (region-end))
+             (comment-kind (f90-ts--comment-block-region beg end)))
+        (cl-destructuring-bind (&optional ck first _) comment-kind
+          (if (eq ck 'block)
+              ;; full block: shrink to first comment node
+              (f90-ts--mark-region-node first f90-ts-mark-region-reversed)
+            (if-let* ((node-on (treesit-node-on beg end))
+                      (node    (f90-ts--smallest-child0-same-span node-on))
+                      (child0  (treesit-node-child node 0 t)))
+                (f90-ts--mark-region-node child0 f90-ts-mark-region-reversed)
+              (message "no tree-sitter child0 found for current region")))))
     (message "no active region")))
 
 
@@ -5392,8 +5508,7 @@ Otherwise mark the region spanned by the node itself (like enlarge-region)."
                 (end (region-end))
                 (node-on (treesit-node-on beg end))
                 (node (f90-ts--largest-node-same-span node-on))
-                (node-mark (if (and (= beg (treesit-node-start node))
-                                    (= end (treesit-node-end node)))
+                (node-mark (if (f90-ts--node-has-span-p node beg end)
                                (treesit-node-prev-sibling node t)
                              node)))
           (f90-ts--mark-region-node node-mark
@@ -5412,8 +5527,7 @@ Otherwise mark the region spanned by the node itself (like enlarge-region)."
                 (end (region-end))
                 (node-on (treesit-node-on beg end))
                 (node (f90-ts--largest-node-same-span node-on))
-                (node-mark (if (and (= beg (treesit-node-start node))
-                                    (= end (treesit-node-end node)))
+                (node-mark (if (f90-ts--node-has-span-p node beg end)
                                (treesit-node-next-sibling node t)
                              node)))
           (f90-ts--mark-region-node node-mark

--- a/test/resources/mark_region.erts
+++ b/test/resources/mark_region.erts
@@ -130,7 +130,7 @@ end subroutine sub_ext_2
 Code:
   (lambda ()
     (f90-ts-mode)
-    (f90-ts-mode-test--modify-region #'f90-ts-child0-region))
+    (f90-ts-mode-test--modify-region #'f90-ts-shrink-region-child0))
 
 Name: mark child0 region 1
 =-=

--- a/test/resources/mark_region.erts
+++ b/test/resources/mark_region.erts
@@ -46,13 +46,28 @@ subroutine sub_init_3()
 end subroutine sub_init_3
 =-=-=
 
+Name: mark initial enlarge region 4
+=-=
+subroutine sub_init_3()
+   i = 6
+   !!$ |i = i + m
+   j = 5
+end subroutine sub_init_3
+=-=
+subroutine sub_init_3()
+   i = 6
+   @!!$ i = i + m|
+   j = 5
+end subroutine sub_init_3
+=-=-=
+
 Code:
   (lambda ()
     (f90-ts-mode)
     (let ((f90-ts-mark-region-reversed t))
       (f90-ts-mode-test--mark-region #'f90-ts-enlarge-region)))
 
-Name: mark initial enlarge region 4
+Name: mark initial enlarge region 5
 =-=
 module mod_init_4
 |   type, public :: t
@@ -85,6 +100,33 @@ end subroutine sub_ext_1
 |
 =-=-=
 
+Name: mark extend enlarge region 2
+=-=
+subroutine sub_ext_2()
+   i = 6
+   ! comment
+   !!$ i = i + m1
+   !!$ i = i + m2
+
+   @!!$ i = i + m3|
+   !!$ i = i + m4
+   ! comment
+   j = 5
+end subroutine sub_ext_2
+=-=
+subroutine sub_ext_2()
+   i = 6
+   ! comment
+   @!!$ i = i + m1
+   !!$ i = i + m2
+
+   !!$ i = i + m3
+   !!$ i = i + m4|
+   ! comment
+   j = 5
+end subroutine sub_ext_2
+=-=-=
+
 Code:
   (lambda ()
     (f90-ts-mode)
@@ -105,6 +147,31 @@ subroutine sub_child0_1()
       end do
    end if
 end subroutine sub_child0_1
+=-=-=
+
+Name: mark child0 region 2
+=-=
+subroutine sub_child0_2()
+   i = 6
+   ! comment
+   @!!$ i = i + m1
+   !!$ i = i + m2
+   !!$ i = i + m3
+   !!$ i = i + m4|
+   ! comment
+   j = 5
+end subroutine sub_child0_2
+=-=
+subroutine sub_child0_2()
+   i = 6
+   ! comment
+   @!!$ i = i + m1|
+   !!$ i = i + m2
+   !!$ i = i + m3
+   !!$ i = i + m4
+   ! comment
+   j = 5
+end subroutine sub_child0_2
 =-=-=
 
 Code:


### PR DESCRIPTION
Handle comment blocks in mark region operations as described in issue #92.