### PR TITLE
Fix which lines to work on in region based completion operation

### DIFF
--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -5095,6 +5095,26 @@ multi-line statements.  Default value is `f90-ts-indent-list-line'."
    (f90-ts--indent-line-aux variant)))
 
 
+(defun f90-ts--complete-end-node-p (node pos end-marker at-col0)
+  "Predicate for `treesit-search-forward' in smart end completion loop.
+Return non-nil if NODE is a completion target within POS and END-MARKER.
+If AT-COL0 is non-nil, do no accept nodes at starting at END-MARKER.
+Thus do not work on nodes at the line if end marker is at column 0.
+
+It throws `f90-ts--past-end' if END-MARKER has been passed, as there is
+no abort mechanism for `treesit-search-foward'."
+  (let ((start-n (treesit-node-start node))
+        (end-n  (f90-ts--node-end-trimmed node)))
+    (when (or (> start-n end-marker)
+              (and at-col0 (= start-n end-marker)))
+      ;; treesit-search-forward has no early abort option,
+      ;; without this, the search exhausts the whole remaining tree
+      (throw 'f90-ts--past-end nil))
+    (and (<= pos end-n)
+         (member (treesit-node-type node)
+                 f90-ts--complete-end-structs))))
+
+
 ;; used by f90-ts-indent-and-complete-region
 (defun f90-ts-complete-smart-end-region (beg end)
   "Execute smart end completion in region from BEG to END."
@@ -5103,37 +5123,29 @@ multi-line statements.  Default value is `f90-ts-indent-list-line'."
        (list (region-beginning) (region-end))
      (list (point-min) (point-max))))
 
-  (let ((beg-pos (if (markerp beg) (marker-position beg) beg))
-        (end-pos (if (markerp end) (marker-position end) end))
-        (end-marker nil))
+  (let* ((beg-pos (if (markerp beg) (marker-position beg) beg))
+         (end-pos (if (markerp end) (marker-position end) end))
+         ;; skip the final line if end-pos is at zeroth column
+         (at-col0 (= 0 (f90-ts--column-number-at-pos end-pos)))
+         (end-marker nil))
     (unwind-protect
         (progn
           (setq end-marker (copy-marker end-pos))
           (catch 'f90-ts--past-end
-           (cl-loop
-            with pos = beg-pos
-            for node = (treesit-search-forward
-                        (treesit-node-at pos)
-                        (lambda (n)
-                          (let ((start-n (treesit-node-start n)))
-                            ;; treesit-search-forward has no early abort
-                            ;; option, without this, the search exhausts
-                            ;; the whole remaining tree
-                            (when (> start-n end-marker)
-                              (throw 'f90-ts--past-end nil))
-                            (and (<= pos start-n)
-                                 (member (treesit-node-type n)
-                                         f90-ts--complete-end-structs))))
-                             nil ; search forward
-                             nil ; only named nodes (end-structs are always named nodes)
-                             )
-            while node
-            do (let ((node-start (treesit-node-start node)))
-                 (f90-ts--complete-smart-end-node node)
-                 (progn ; or better save-excursion (seems unnecessary?)
-                   (goto-char node-start)
-                   (forward-line 1)
-                   (setq pos (point))))))
+            (cl-loop
+             with pos = beg-pos
+             for node = (treesit-search-forward
+                         (treesit-node-at pos)
+                         (lambda (n)
+                           (f90-ts--complete-end-node-p n pos end-marker at-col0))
+                         nil  ; search forward
+                         nil) ; only named nodes (end-structs are always named nodes)
+             while node
+             do (let ((node-start (treesit-node-start node)))
+                  (f90-ts--complete-smart-end-node node)
+                  (goto-char node-start)
+                  (forward-line 1)
+                  (setq pos (point)))))
           ;; after finishing move to end of region
           (goto-char end-marker))
       (set-marker end-marker nil))))

--- a/test/f90-ts-mode-test.el
+++ b/test/f90-ts-mode-test.el
@@ -803,15 +803,29 @@ PREFIX is the test name prefix, usually \"f90-ts-mode-test-std\"."
 ;;------------------------------------------------------------------------------
 ;; mark region helpers
 
-(defun f90-ts-mode-test--mark-region (command)
-  "Test function for mark region with no prior region selected.
-Execute COMMAND, which marks some region and insert markers @..| for
-result region."
+(defun f90-ts-mode-test--mark-region-pre (command)
+  "Mark region before COMMAND is executed.
+Use markers @..| to find region for COMMAND to work on."
+  (let ((pos (point)))
+    (goto-char (point-min))
+    (search-forward "@")
+    ;; point is after marker @, so delete before
+    (delete-char -1)
+    (push-mark (point) t t)
+    (if (< (point) pos)
+        (goto-char (1- pos))
+      (goto-char pos))
+    (funcall command)))
+
+
+(defun f90-ts-mode-test--mark-region-post (command)
+  "Insert markers into result buffer after executing COMMAND..
+Insert markers @..| for result region."
   (funcall command)
   (f90-ts-mode-test--insert-region-markers))
 
 
-(defun f90-ts-mode-test--modify-region (command)
+(defun f90-ts-mode-test--mark-region-modify (command)
   "Setup pre-selected region and apply COMMAND for modifying region.
 Set up region from @ to | markers, then call COMMAND and reinsert @..| markers
 for modified region."

--- a/test/resources/indent_region_partial.erts
+++ b/test/resources/indent_region_partial.erts
@@ -3,14 +3,15 @@ Point-Char: |
 Code:
   (lambda ()
     (f90-ts-mode)
-    (indent-region 1 54))
+    (f90-ts-mode-test--mark-region-pre
+      (lambda () (f90-ts-indent-and-complete-region (region-beginning) (region-end)))))
 
 Name: indent region partial start
 =-=
-|subroutine sub_1()
+@subroutine sub_1()
 call sub_2()
 end subroutine sub_1
-
+|
 subroutine sub_2()
 call sub_3()
 end subroutine sub_2
@@ -32,21 +33,16 @@ call sub_1()
 end subroutine sub_3
 =-=-=
 
-Code:
-  (lambda ()
-    (f90-ts-mode)
-    (indent-region 55 108))
-
 Name: indent region partial middle
 =-=
-|subroutine sub_1()
+subroutine sub_1()
 call sub_2()
 end subroutine sub_1
 
-subroutine sub_2()
+@subroutine sub_2()
 call sub_3()
 end subroutine sub_2
-
+|
 subroutine sub_3()
 call sub_1()
 end subroutine sub_3
@@ -64,14 +60,9 @@ call sub_1()
 end subroutine sub_3
 =-=-=
 
-Code:
-  (lambda ()
-    (f90-ts-mode)
-    (indent-region 109 162))
-
 Name: indent region partial end
 =-=
-|subroutine sub_1()
+subroutine sub_1()
 call sub_2()
 end subroutine sub_1
 
@@ -79,10 +70,10 @@ subroutine sub_2()
 call sub_3()
 end subroutine sub_2
 
-subroutine sub_3()
+@subroutine sub_3()
 call sub_1()
 end subroutine sub_3
-
+|
 =-=
 subroutine sub_1()
 call sub_2()

--- a/test/resources/indent_region_partial.erts
+++ b/test/resources/indent_region_partial.erts
@@ -88,3 +88,50 @@ subroutine sub_3()
 end subroutine sub_3
 |
 =-=-=
+
+Name: end statement at column-0
+=-=
+subroutine sub
+x = 1
+y @= 2
+|end
+=-=
+subroutine sub
+x = 1
+     y = 2
+|end
+=-=-=
+
+Name: end statement at column-1
+=-=
+subroutine sub
+x = 1
+y @= 2
+e|nd
+=-=
+subroutine sub
+x = 1
+     y = 2
+|end subroutine sub
+=-=-=
+
+Name: end statement after
+=-=
+subroutine sub
+x = 1
+y = 2
+e@nd
+
+subroutine foo
+|end
+
+=-=
+subroutine sub
+x = 1
+y = 2
+end subroutine sub
+
+subroutine foo
+|end
+
+=-=-=

--- a/test/resources/mark_region.erts
+++ b/test/resources/mark_region.erts
@@ -3,7 +3,7 @@ Point-Char: |
 Code:
   (lambda ()
     (f90-ts-mode)
-    (f90-ts-mode-test--mark-region #'f90-ts-mark-region-enlarge))
+    (f90-ts-mode-test--mark-region-post #'f90-ts-mark-region-enlarge))
 
 Name: mark initial enlarge region 1
 =-=
@@ -65,7 +65,7 @@ Code:
   (lambda ()
     (f90-ts-mode)
     (let ((f90-ts-mark-region-order 'start))
-      (f90-ts-mode-test--mark-region #'f90-ts-mark-region-enlarge)))
+      (f90-ts-mode-test--mark-region-post #'f90-ts-mark-region-enlarge)))
 
 Name: mark initial enlarge region 5
 =-=
@@ -87,7 +87,7 @@ Code:
   (lambda ()
     (f90-ts-mode)
     (let ((f90-ts-mark-region-order 'preserve))
-      (f90-ts-mode-test--mark-region #'f90-ts-mark-region-enlarge)))
+      (f90-ts-mode-test--mark-region-post #'f90-ts-mark-region-enlarge)))
 
 Name: mark initial enlarge region 6
 =-=
@@ -107,7 +107,7 @@ end module mod_init_4
 Code:
   (lambda ()
     (f90-ts-mode)
-    (f90-ts-mode-test--modify-region #'f90-ts-mark-region-enlarge))
+    (f90-ts-mode-test--mark-region-modify #'f90-ts-mark-region-enlarge))
 
 Name: mark extend enlarge region 1
 =-=
@@ -185,7 +185,7 @@ Code:
   (lambda ()
     (f90-ts-mode)
     (let ((f90-ts-mark-region-order 'start))
-      (f90-ts-mode-test--modify-region #'f90-ts-mark-region-enlarge)))
+      (f90-ts-mode-test--mark-region-modify #'f90-ts-mark-region-enlarge)))
 
 Name: mark extend enlarge region 5
 =-=
@@ -203,7 +203,7 @@ Code:
   (lambda ()
     (f90-ts-mode)
     (let ((f90-ts-mark-region-order 'preserve))
-      (f90-ts-mode-test--modify-region #'f90-ts-mark-region-enlarge)))
+      (f90-ts-mode-test--mark-region-modify #'f90-ts-mark-region-enlarge)))
 
 Name: mark extend enlarge region 5
 =-=
@@ -219,7 +219,7 @@ end subroutine sub_ext_5@
 Code:
   (lambda ()
     (f90-ts-mode)
-    (f90-ts-mode-test--modify-region #'f90-ts-mark-region-shrink-child-first))
+    (f90-ts-mode-test--mark-region-modify #'f90-ts-mark-region-shrink-child-first))
 
 Name: mark child0 region 1
 =-=
@@ -266,7 +266,7 @@ end subroutine sub_child0_2
 Code:
   (lambda ()
     (f90-ts-mode)
-    (f90-ts-mode-test--modify-region #'f90-ts-mark-region-shrink-child-last))
+    (f90-ts-mode-test--mark-region-modify #'f90-ts-mark-region-shrink-child-last))
 
 Name: mark child9 region 1
 =-=
@@ -313,7 +313,7 @@ end subroutine sub_child9_2
 Code:
   (lambda ()
     (f90-ts-mode)
-    (f90-ts-mode-test--modify-region #'f90-ts-mark-region-first-sibling))
+    (f90-ts-mode-test--mark-region-modify #'f90-ts-mark-region-first-sibling))
 
 Name: mark first region 1
 =-=
@@ -336,7 +336,7 @@ end subroutine sub_first_1
 Code:
   (lambda ()
     (f90-ts-mode)
-    (f90-ts-mode-test--modify-region #'f90-ts-mark-region-prev-sibling))
+    (f90-ts-mode-test--mark-region-modify #'f90-ts-mark-region-prev-sibling))
 
 Name: mark prev region 1
 =-=
@@ -589,7 +589,7 @@ end subroutine sub
 Code:
   (lambda ()
     (f90-ts-mode)
-    (f90-ts-mode-test--modify-region #'f90-ts-mark-region-next-sibling))
+    (f90-ts-mode-test--mark-region-modify #'f90-ts-mark-region-next-sibling))
 
 Name: mark next region 1
 =-=
@@ -835,7 +835,7 @@ end subroutine sub
 Code:
   (lambda ()
     (f90-ts-mode)
-    (f90-ts-mode-test--modify-region #'f90-ts-mark-region-last-sibling))
+    (f90-ts-mode-test--mark-region-modify #'f90-ts-mark-region-last-sibling))
 
 Name: mark last region 1
 =-=
@@ -858,7 +858,7 @@ Code:
   (lambda ()
     (f90-ts-mode)
     (let ((f90-ts-mark-region-order 'preserve))
-      (f90-ts-mode-test--modify-region #'f90-ts-mark-region-next-sibling)))
+      (f90-ts-mode-test--mark-region-modify #'f90-ts-mark-region-next-sibling)))
 
 Name: mark sibling region preserve 1
 =-=
@@ -898,7 +898,7 @@ Code:
   (lambda ()
     (f90-ts-mode)
     (let ((f90-ts-mark-region-order 'start))
-      (f90-ts-mode-test--modify-region #'f90-ts-mark-region-next-sibling)))
+      (f90-ts-mode-test--mark-region-modify #'f90-ts-mark-region-next-sibling)))
 
 Name: mark sibling region start 1
 =-=


### PR DESCRIPTION
Fix which lines to work on in region based completion operation. If start of region is within an end-node, then complete this node. If end point is at start of a line containing an end, then do not apply completion to that end. This mimics the behaviour of indent-region.

Also, add f90-ts-mode-test-mark-region-... macros to simplify testing of operations working on partial region.

This kind of closes issue #138, which could not be reproduced, but surfaced these related issues.