### PR TITLE
Allow non-blank separated comment prefixes

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -31,6 +31,7 @@ for implementation.
   - [Imenu](#imenu)
   - [Navigation menu](#navigation-menu)
   - [Navigation buffer](#navigation-buffer)
+  - [Comment prefix](#comment-prefix)
   - [Breaking and joining lines](#breaking-and-joining-lines)
     - [Breaking lines](#breaking-lines)
     - [Joining lines](#joining-lines)
@@ -541,6 +542,26 @@ Keybindings in the navigation buffer:
 Note: the navigation buffer is still missing some features to be really useful.
 
 
+### Comment prefix
+
+Various operations, in particular break, join, fill and mark operations require to match and extract
+comment prefixes.
+The comment prefix is found by regexp `f90-ts-comment-prefix-regexp` in combination with separator
+`f90-ts-comment-prefix-separator-regexp`, which can be customized if necessary.
+
+To be precise the comment prefix is matched and extracted by match groups 1, 2 or 3 of
+```elisp
+  (concat "^\\(?:"
+          "\\(" f90-ts-openmp-prefix-regexp "\\)\\(?:\\s-\\|$\\)"
+          "\\|\\(" f90-ts-comment-prefix-regexp "\\)"
+          (when f90-ts-comment-prefix-separator-regexp
+            (concat "\\(?:" f90-ts-comment-prefix-separator-regexp "\\|$\\)"))
+          ;; if nothing matches, then extract the leading comment starter
+          "\\|\\(!\\)"
+          "\\)"))
+```
+where the single `!` is always matched to cover all not yet matched prefixes.
+
 
 ### Breaking and joining lines
 
@@ -557,10 +578,9 @@ These operations are inspired by the legacy f90 mode, but behave a bit different
 #### Breaking lines
 
 The function `f90-ts-break-line` breaks the current line at point and adds continuation symbols.
-If the current line is a comment,
-then the comment starter (like '!>', '!<' or similar) is extracted, including indentation offset after the
-comment starter, and inserted into the new line to continue the comment.
-The comment starter is found by regexp `f90-ts-comment-prefix-regexp`, which can be customized if necessary.
+If the current line is a comment, then the comment prefix (like '!>', '!<' or similar) is extracted,
+including indentation offset after the comment prefix, and inserted into the new line to continue the comment.
+See [Comment prefix](#comment-prefix) for details.
 
 Whether a leading ampersand at the start of the new line is inserted is controlled by option
 `f90-ts-leading-ampersand`.
@@ -568,23 +588,22 @@ Whether a leading ampersand at the start of the new line is inserted is controll
 
 #### Joining lines
 
-Two consecutive lines connected by continuation symbol `&` can be joined by
-`f90-ts-join-line-prev` and `f90-ts-join-line-next`.
-The ampersand(s) in between are removed.
-One whitespace character is left after putting the second line at the end of the first line.
+Consecutive lines can be joined by `f90-ts-join-line-prev` and `f90-ts-join-line-next`
+under various circumstances, which are:
+
+- two consecutive lines connected by continuation symbol `&`.
+- some statement followed by empty line(s) (join-line-prev)
+- empty line(s) followed by some statement (join-line-next)
+- comments with the same comment prefix (see [Comment prefix](#comment-prefix) for details)
+- comment after a continued line (join-line-prev)
+- continued line followed by a comment (join-line-next)
+- continued string
+
+The ampersand(s) or comment prefixes in between are removed, where necessary, adding
+one whitespace character where applicable.
 
 If there are empty lines, then only the empty lines are removed, without joining the lines.
-A second join operation can be used to actually join the lines. 
-
-If there are comments at end of first line or in between the two lines, joining is not possible,
-as it is not quite clear what should be done with such comments.
-
-If point is on an empty line (not necessarily within a continued statement),
-then previous (prev variant) or subsequent (next variant) empty lines are removed,
-but nothing is joined in any case.
-
-The `prev` variant joins current line with previous (non-empty) line.
-The `next` variant joins current line with next (non-empty) line.
+A second join operation can be used to actually join the lines.
 
 Current limitations are:
 * Comments within string literals are not supported by the tree-sitter grammar itself.
@@ -627,8 +646,8 @@ be preserved (defaulting to end position if no active region is present).
 
 Blocks of nodes of the same kind are grouped and and dealt with like
 the block would be represented by a node in the tree (which they are not).
-Currently comments with the same comment prefix extracted by `f90-ts-comment-prefix-regexp`
-are recognised. (Other groups like use statements or public statements could be added in the future.)
+Currently comments with the same comment prefix are recognised (see [Comment prefix](#comment-prefix)).
+(Other groups like use statements or public statements could be added in the future.)
 
 Identifying comments with the same comment prefix and including those in mark region operations
 is particularly useful in conjunction with comment region operations.

--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@ including syntax highlighting, indentation, navigation, and structural editing f
 **06-2026**
  - Indentation of lines after a structure beginning line with statement label fixed.
  - Indentation within and after preprocessor blocks fixed.
- - Trailing blank part `\\(\\s-+\\|$\\)` in defcustom regexps
-   `f90-ts-comment-prefix-regexp` and `f90-ts-openmp-prefix-regexp` has
-   been removed from the defcustom definitions and is now always appended
-   internally. If these variables have been customized, please adjust.
+ - Trailing blank part "\\(\\s-+\\|$\\)" in defcustom regexps
+   `f90-ts-comment-prefix-regexp` and `f90-ts-openmp-prefix-regexp`
+   removed from the defcustom definitions and added as
+   `f90-ts-comment-prefix-separator-regexp`.  If the regexp
+   variables have been customized, please adjust.
+   (See [MANUAL.md](MANUAL.md#comment-prefix) for details.)
 
 
 ## Keybindings

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -1784,11 +1784,15 @@ TODO: besides ampersands also skip statement_label's."
 
 
 (defun f90-ts--node-at-indent-pos (pos)
-  "Determine node at indentation position of line determined by POS."
+  "Determine node at indentation position of line determined by POS.
+If the line is empty, return nil."
   (save-excursion
     (goto-char pos)
     (back-to-indentation)
-    (treesit-node-at (point))))
+    (let ((node (treesit-node-at (point))))
+      (when (and node
+                 (= (point) (treesit-node-start node)))
+        node))))
 
 
 ;;;-----------------------------------------------------------------------------

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -37,9 +37,9 @@
 ;;   [06-2026] Indentation within and after preprocessor blocks fixed.
 ;;   [06-2026] Trailing blank part "\\(\\s-+\\|$\\)" in defcustom regexps
 ;;             `f90-ts-comment-prefix-regexp' and `f90-ts-openmp-prefix-regexp'
-;;             has been removed from the defcustom definitions and is now
-;;             always appended internally.  If these variables have been
-;;             customized, please adjust.
+;;             removed from the defcustom definitions and added as
+;;             `f90-ts-comment-prefix-separator-regexp'.  If the regexp
+;;             variables have been customized, please adjust.
 ;;
 ;; Features:
 ;;   - Almost all statements up to F2023
@@ -474,12 +474,42 @@ For matching identifiers the face `f90-ts-font-lock-special-var' is used."
 
 (defcustom f90-ts-comment-prefix-regexp "!\\S-*"
   "Regular expression for matching and capturing comment starts.
-This is used to extract the comment prefix for `f90-ts-break-line',
-`f90-ts-join-line-prev' and `f90-ts-join-line-next' operations.
+Together with `f90-ts-comment-prefix-separator-regexp', this is used to extract
+the comment prefix for `f90-ts-break-line', `f90-ts-join-line-prev' and
+`f90-ts-join-line-next' operations.
 OpenMP prefix is matched by `f90-ts-openmp-prefix-regexp'.
 
-The variable should also add trailing whitespace characters to
-preserve indentation within comments with `f90-ts-break-line'."
+Note: do *NOT* use capturing groups in the regular expression, otherwise
+comment prefix matching fails.  If a group is required, then use non-capturing
+groups with \"\\(?:regexp\\)\".  Example: \"!\\(?:doc\\|remark\\|!\\$\\)\".
+
+The default value \"!\\S-*\" with separator \"\\s-\" assumes that the comment
+prefixes are always separated by a blank.  If comment content starts right
+after the comment start \"!\", then these two regexp must be adjusted to
+properly match only desired comment starters without any separator."
+  :type  'regexp
+  :safe  #'stringp
+  :group 'f90-ts)
+
+
+(defcustom f90-ts-comment-prefix-separator-regexp "\\s-"
+  "Regular expression for separating comment prefix and its content.
+End-of-string always serves as separator as well and does not need to provided.
+
+If comment content regularly starts right after comment start \"!\", then this
+should be disabled and `f90-ts-comment-prefix-regexp' properly formulate to
+match only exactly desired prefixes."
+  :type '(choice (regexp :tag "Separator regexp")
+                 (const :tag "No separator" nil))
+  :safe (lambda (v) (or (null v) (stringp v)))
+  :group 'f90-ts)
+
+
+(defcustom f90-ts-openmp-prefix-regexp "!\\$\\(?:omp\\)?"
+  "Regular expression for matching OpenMP starts.
+It is used for identifying openmp statements, which are just comment nodes.
+For example, this is relevant for line break operations, as openmp statements
+require continuation symbols."
   :type  'regexp
   :safe  #'stringp
   :group 'f90-ts)
@@ -523,17 +553,6 @@ defaulting to end of region if there is no active region present."
                   (const :tag "Point at end" end)
                   (const :tag "Preserve order" preserve))
   :safe  (lambda (v) (memq v '(start end preserve)))
-  :group 'f90-ts)
-
-
-(defcustom f90-ts-openmp-prefix-regexp "!\\$\\(?:omp\\)?"
-  "Regular expression for matching OpenMP starts.
-This is used for line break operations, as openmp statements require
-continuation symbols.
-The defcustom should also add trailing whitespace characters to preserve
-indentation within OpenMP statements."
-  :type  'regexp
-  :safe  #'stringp
   :group 'f90-ts)
 
 
@@ -993,6 +1012,41 @@ is matched by TYPE-RX."
        (= end (treesit-node-end node))))
 
 
+(defun f90-ts--comment-omp-prefix-regexp ()
+  "Return the combined comment and openmp prefix regexp.
+The returned regexp also captures trailing blanks, which serves as an assertion
+that the prefix is properly separated by a blank.  If accessing the captured
+prefix, match group 1 needs to be used."
+  ;; first match openmp as comment prefix might just take the initial ! and
+  ;; ignore the following $omp part in openmp statements
+  (concat "^\\(?:"
+          "\\(" f90-ts-openmp-prefix-regexp "\\)\\(?:\\s-\\|$\\)"
+          "\\|\\(" f90-ts-comment-prefix-regexp "\\)"
+          (when f90-ts-comment-prefix-separator-regexp
+            (concat "\\(?:" f90-ts-comment-prefix-separator-regexp "\\|$\\)"))
+          ;; if nothing matches, then extract the leading comment starter
+          "\\|\\(!\\)"
+          "\\)"))
+
+
+(defun f90-ts--match-comment-omp-prefix (text)
+  "Match a comment prefix at the start of TEXT.
+Returns the prefix in the comment TEXT if matched, nil otherwise.
+It uses `f90-ts--comment-omp-prefix-regexp' to capture the prefix."
+  (when (string-match (f90-ts--comment-omp-prefix-regexp) text)
+    (or (match-string 1 text)
+        (match-string 2 text)
+        (match-string 3 text))))
+
+
+(defun f90-ts--comment-omp-prefix-with-blanks (text prefix)
+  "Return PREFIX extended by any blanks following it in TEXT.
+Used to capture trailing blanks in comment and openmp prefixes."
+  (let ((pos (length prefix)))
+    (string-match "\\s-*" text pos)
+    (substring text 0 (match-end 0))))
+
+
 (defun f90-ts--comment-prefix (node trim)
   "Extract the starting character sequence from a comment NODE.
 NODE is assumed to be of type comment.  It uses `f90-ts-openmp-prefix-regexp'
@@ -1002,16 +1056,49 @@ If TRIM is `trimmed', only the matched prefix is returned."
   (cl-assert (f90-ts--node-type-p node "comment")
              nil "comment-prefix: comment node expected")
   (cl-assert (memq trim '(with-blanks trimmed)) nil "argument trim has invalid value, got %s" trim)
+  (let* ((text (treesit-node-text node))
+         (prefix (f90-ts--match-comment-omp-prefix text)))
+    ;; there should always be a prefix, as a single "!" is captured as well
+    (cl-assert prefix nil "comment has no prefix")
+    (if (eq trim 'with-blanks)
+        (f90-ts--comment-omp-prefix-with-blanks text prefix)
+      prefix)))
 
+
+(defun f90-ts--comment-content (node)
+  "Extract the content of a comment NODE following the comment prefix.
+NODE is assumed to be of type comment.  It uses `f90-ts-openmp-prefix-regexp'
+and `f90-ts-comment-prefix-regexp' to identify the prefix to extract.
+It always removes blanks after the prefix.  Thus the first character in the
+returned content is a non-blank character, or content is nil."
+  (cl-assert (f90-ts--node-type-p node "comment")
+             nil "comment node expected")
+  (let* ((text (treesit-node-text node))
+         (prefix (f90-ts--match-comment-omp-prefix text)))
+    (cl-assert prefix nil "comment has no prefix")
+    (let ((pos (length prefix)))
+      (string-match "\\s-*" text pos)
+      (let ((content-start (match-end 0)))
+        (when (< content-start (length text))
+          (substring text content-start))))))
+
+
+(defun f90-ts--comment-forward-prefix (node)
+  "Position point at end of comment prefix matched at start of NODE.
+NODE is assumed to be of type comment.  It uses `f90-ts-openmp-prefix-regexp'
+and `f90-ts-comment-prefix-regexp' to identify the prefix to extract."
+  (cl-assert (f90-ts--node-type-p node "comment")
+             nil "comment node expected")
   ;; first match openmp as comment prefix would just take the initial ! and ignoring
   ;; following $omp part in openmp statements
-  (let* ((text (treesit-node-text node))
-         (rx-comment (concat "^\\(\\(?:" f90-ts-openmp-prefix-regexp "\\)\\|\\(?:"
-                             f90-ts-comment-prefix-regexp "\\)\\)\\(\\s-+\\|$\\)")))
-    (when (string-match rx-comment text)
-      (if (eq trim 'with-blanks)
-          (match-string 0 text)
-        (match-string 1 text)))))
+  (let ((start (treesit-node-start node))
+        (end (treesit-node-end node)))
+    (goto-char start)
+    (re-search-forward (f90-ts--comment-omp-prefix-regexp)
+                       end t)
+    ;; rx-comment contains trailing blanks as an assertion, skip-backwards
+    ;; to end of comment prefix
+    (skip-chars-backward " \t")))
 
 
 (defun f90-ts--node-special-var-p (node)

--- a/test/f90-ts-mode-test.el
+++ b/test/f90-ts-mode-test.el
@@ -148,6 +148,7 @@ without final newline."
     (f90-ts-stmt-label-column . (left . 0))
     (f90-ts-special-comment-rules . ,f90-ts-mode-test--special-comment-rules)
     (f90-ts-comment-prefix-regexp . "!\\S-*")
+    (f90-ts-comment-prefix-separator-regexp . "\\s-")
     (f90-ts-openmp-prefix-regexp . "!\\$\\(?:omp\\)?")
     (f90-ts-special-var-regexp . "\\_<\\(self\\|this\\)\\_>")
     (f90-ts-comment-keyword-regexp . "\\<\\(TODO\\|FIXME\\|Remarks?\\)\\>")
@@ -946,6 +947,7 @@ If buffer was modified, insert `**' otherwise insert '--'."
    "join_line.erts"
    "mark_region.erts"
    "comment_region.erts"
+   "comment_prefix.erts"
    "modified_bit.erts"))
 
 

--- a/test/resources/comment_prefix.erts
+++ b/test/resources/comment_prefix.erts
@@ -1,0 +1,215 @@
+Point-Char: |
+
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (f90-ts-mode-test--mark-region-modify #'f90-ts-mark-region-enlarge))
+
+Name: comment prefix 1
+=-=
+subroutine sub()
+   i = 6
+   !!$ comment 1
+   !!$ comment 2
+   @!!$ comment 3|
+   !!$ comment 4
+   j = 5
+end subroutine sub
+=-=
+subroutine sub()
+   i = 6
+   @!!$ comment 1
+   !!$ comment 2
+   !!$ comment 3
+   !!$ comment 4|
+   j = 5
+end subroutine sub
+=-=-=
+
+Name: comment prefix 2
+=-=
+subroutine sub()
+   i = 6
+   ! match simple comment prefix
+   !!$ comment 1
+   ! comment 2
+   @! comment 3|
+   !!$ comment 4
+   j = 5
+end subroutine sub
+=-=
+subroutine sub()
+   i = 6
+   ! match simple comment prefix
+   !!$ comment 1
+   @! comment 2
+   ! comment 3|
+   !!$ comment 4
+   j = 5
+end subroutine sub
+=-=-=
+
+Name: comment prefix 3
+=-=
+subroutine sub()
+   i = 6
+   !!$comment 1
+   !!$comment 2
+   @!!$comment 3|
+   !!$comment 4
+   j = 5
+end subroutine sub
+=-=
+subroutine sub()
+   i = 6
+   @!!$comment 1
+   !!$comment 2
+   !!$comment 3
+   !!$comment 4|
+   j = 5
+end subroutine sub
+=-=-=
+
+Name: comment prefix 4
+=-=
+subroutine sub()
+   i = 6
+   !!$comment 1
+   !comment 2
+   @!comment 3|
+   !!$comment 4
+   j = 5
+end subroutine sub
+=-=
+subroutine sub()
+   i = 6
+   !!$comment 1
+   @!comment 2
+   !comment 3|
+   !!$comment 4
+   j = 5
+end subroutine sub
+=-=-=
+
+Name: comment prefix 5
+=-=
+subroutine sub()
+   i = 6
+   ! all different prefixes, hence do not recognise as group
+   !!$comment1
+   !!$comment2
+   @!!$comment3|
+   !!$comment4
+   j = 5
+end subroutine sub
+
+=-=
+@subroutine sub()
+   i = 6
+   ! all different prefixes, hence do not recognise as group
+   !!$comment1
+   !!$comment2
+   !!$comment3
+   !!$comment4
+   j = 5
+end subroutine sub|
+
+=-=-=
+
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (let ((f90-ts-comment-prefix-regexp "!\\(?:doc\\|remark\\|!\\$\\)")
+          (f90-ts-comment-prefix-separator-regexp nil))
+      (f90-ts-mode-test--mark-region-modify #'f90-ts-mark-region-enlarge)))
+
+Name: comment prefix 6
+=-=
+subroutine sub()
+   i = 6
+   !!$ comment 1
+   !!$ comment 2
+   @!!$ comment 3|
+   !!$ comment 4
+   j = 5
+end subroutine sub
+=-=
+subroutine sub()
+   i = 6
+   @!!$ comment 1
+   !!$ comment 2
+   !!$ comment 3
+   !!$ comment 4|
+   j = 5
+end subroutine sub
+=-=-=
+
+Name: comment prefix 7
+=-=
+subroutine sub()
+   i = 6
+   ! no separator required, hence still a group
+   !!$comment1
+   !!$comment2
+   @!!$comment3|
+   !!$comment4
+   j = 5
+end subroutine sub
+=-=
+subroutine sub()
+   i = 6
+   ! no separator required, hence still a group
+   @!!$comment1
+   !!$comment2
+   !!$comment3
+   !!$comment4|
+   j = 5
+end subroutine sub
+=-=-=
+
+Name: comment prefix 8
+=-=
+subroutine sub()
+   i = 6
+   !doc comment1
+   !doc comment2
+   @!remark comment3|
+   !remark comment4
+   !comment5
+   j = 5
+end subroutine sub
+=-=
+subroutine sub()
+   i = 6
+   !doc comment1
+   !doc comment2
+   @!remark comment3
+   !remark comment4|
+   !comment5
+   j = 5
+end subroutine sub
+=-=-=
+
+Name: comment prefix 9
+=-=
+subroutine sub()
+   i = 6
+   ! no separator required, captured by fallback single !
+   !comment1
+   !comment2
+   @!comment3|
+   !comment4
+   j = 5
+end subroutine sub
+=-=
+subroutine sub()
+   i = 6
+   @! no separator required, captured by fallback single !
+   !comment1
+   !comment2
+   !comment3
+   !comment4|
+   j = 5
+end subroutine sub
+=-=-=
+


### PR DESCRIPTION
Allow non-blank separated comment prefixes, by putting the separation regexp into new defcustom f90-ts-comment-prefix-separator-regexp 