### PR TITLE
Fix smart end completion for coarray "end team" statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ For a comprehensive overview see [MANUAL.md](MANUAL.md).
 
 ### Recently added, changed or improved
 
+**08-2026**
+ - Smart end completion of coarray "change team ... end team" blocks fixed. It was
+   wrongly assumed that the end statement is "end change team".
+
 **07-2026**
  - Inherit attribute of some font lock faces fixed.
  - Alignment of unary expressions with leading minus or plus improved.

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -32,8 +32,12 @@
 ;; files, based on Emacs's built-in tree-sitter support (requires Emacs 30+)
 ;;
 ;; Recently changed, added or improved:
+;;   [08-2026] Smart end completion of coarray "change team ... end team" blocks fixed.
+;;             It was wrongly assumed that the end statement is "end change team".
+;;
 ;;   [07-2026] Inherit attribute of some font lock faces fixed.
 ;;   [07-2026] Alignment of unary expressions with leading minus or plus improved.
+;;
 ;;   [06-2026] Fill line and region operations added.
 ;;   [06-2026] Defcustom group f90-ts-comment added.
 ;;   [06-2026] Indentation of lines after a structure beginning line with
@@ -4927,7 +4931,8 @@ Return non-nil if something was changed and text actually replaced."
                                           " (type_name) @name"
                                           "))"))
     ("coarray_critical_statement" . "(coarray_critical_statement (block_label_start_expression _ @name \":\")? \"critical\" @construct)")
-    ("coarray_team_statement"     . "(coarray_team_statement (block_label_start_expression _ @name \":\")? \"change\" @construct \"team\" @construct2)"))
+    ;; this is counter intuitive: "change team" is ended by "end team" not by "end change team"
+    ("coarray_team_statement"     . "(coarray_team_statement (block_label_start_expression _ @name \":\")? \"change\" \"team\" @construct)"))
   "Treesitter queries to extract relevant nodes for smart end completion.")
 
 

--- a/test/f90-ts-mode-test.el
+++ b/test/f90-ts-mode-test.el
@@ -924,6 +924,7 @@ If buffer was modified, insert `**' otherwise insert '--'."
    "indent_region_select.erts"
    "indent_region_preproc.erts"
    "indent_region_openmp.erts"
+   "indent_region_coarray.erts"
    "indent_region_stmt_label.erts")
  '(nil ; no modification
    f90-ts-mode-test--remove-indent

--- a/test/resources/fill_operations.erts
+++ b/test/resources/fill_operations.erts
@@ -390,6 +390,7 @@ Code:
   (lambda ()
     (f90-ts-mode)
     (let ((fill-column 40)
+          (inhibit-message t)
           (f90-ts-fill-select-breakpoint-by 'interactive))
       (f90-ts-mode-test--with-mocked-keys
        '[left return right backspace end left left left left left left return space delete home right right right right right right delete left left delete left left return backspace return right return ?q]
@@ -425,6 +426,7 @@ Code:
   (lambda ()
     (f90-ts-mode)
     (let ((fill-column 40)
+          (inhibit-message t)
           (f90-ts-fill-select-breakpoint-by 'interactive))
       (f90-ts-mode-test--with-mocked-keys
        '[space left left return delete space space space space delete delete space space left return space]
@@ -467,6 +469,7 @@ Code:
   (lambda ()
     (f90-ts-mode)
     (let ((fill-column 40)
+          (inhibit-message t)
           (f90-ts-fill-select-breakpoint-by 'interactive))
       (f90-ts-mode-test--with-mocked-keys
        '[space space left return return left return]
@@ -491,6 +494,7 @@ Code:
   (lambda ()
     (f90-ts-mode)
     (let ((fill-column 40)
+          (inhibit-message t)
           (f90-ts-fill-select-breakpoint-by 'interactive))
       (f90-ts-mode-test--with-mocked-keys
        '[space ?q left return return left return]

--- a/test/resources/font_lock_coarray.f90
+++ b/test/resources/font_lock_coarray.f90
@@ -1,6 +1,9 @@
  program coarray_test
 !^^^^^^^ font-lock-keyword-face
 !        ^^^^^^^^^^^^ font-lock-function-name-face
+  use iso_fortran_env
+! ^^^ font-lock-keyword-face
+!     ^^^^^^^^^^^^^^^ nil
   implicit none
 ! ^^^^^^^^ font-lock-keyword-face
 !          ^^^^ font-lock-keyword-face
@@ -50,13 +53,13 @@
 !          ^^^^^^^^^^^^^^^^^^^^^^ font-lock-keyword-face
 !                                 ^^ f90-ts-font-lock-delimiter-face
 !                                    ^^^ nil
-  integer :: team_value[*]
-! ^^^^^^^ font-lock-type-face
-!         ^^ f90-ts-font-lock-delimiter-face
-!            ^^^^^^^^^^ nil
-!                      ^ f90-ts-font-lock-bracket-face
-!                       ^ nil
-!                        ^ f90-ts-font-lock-bracket-face
+  type(team_type) :: team_value
+! ^^^^ font-lock-keyword-face
+!     ^ f90-ts-font-lock-bracket-face
+!      ^^^^^^^^^ font-lock-type-face
+!               ^ f90-ts-font-lock-bracket-face
+!                 ^^ f90-ts-font-lock-delimiter-face
+!                    ^^^^^^^^^^ nil
   type(lock_type), codimension[*] :: mylock
 ! ^^^^ font-lock-keyword-face
 !     ^ f90-ts-font-lock-bracket-face
@@ -67,14 +70,14 @@
 !                                 ^^ f90-ts-font-lock-delimiter-face
 !                                    ^^^^^^ nil
 
-  scalar_co[1]       = 42
+  scalar_co[1]      = 42
 ! ^^^^^^^^^ nil
 !          ^ f90-ts-font-lock-bracket-face
 !           ^ font-lock-number-face
 !            ^ f90-ts-font-lock-bracket-face
-!                    ^ f90-ts-font-lock-operator-face
-!                      ^^ font-lock-number-face
-  arr(5)[1, 2]       = 3.14
+!                   ^ f90-ts-font-lock-operator-face
+!                     ^^ font-lock-number-face
+  arr(5)[1, 2]      = 3.14
 ! ^^^ nil
 !    ^ f90-ts-font-lock-bracket-face
 !     ^ font-lock-number-face
@@ -83,16 +86,16 @@
 !         ^ f90-ts-font-lock-delimiter-face
 !           ^ font-lock-number-face
 !            ^ f90-ts-font-lock-bracket-face
-!                    ^ f90-ts-font-lock-operator-face
-!                      ^^^^ font-lock-number-face
-  val[this_image()]  = this_image()
+!                   ^ f90-ts-font-lock-operator-face
+!                     ^^^^ font-lock-number-face
+  val[this_image()] = this_image()
 ! ^^^ nil
 !    ^ f90-ts-font-lock-bracket-face
 !     ^^^^^^^^^^ font-lock-builtin-face
 !               ^^^ f90-ts-font-lock-bracket-face
-!                    ^ f90-ts-font-lock-operator-face
-!                      ^^^^^^^^^^ font-lock-builtin-face
-!                                ^^ f90-ts-font-lock-bracket-face
+!                   ^ f90-ts-font-lock-operator-face
+!                     ^^^^^^^^^^ font-lock-builtin-face
+!                               ^^ f90-ts-font-lock-bracket-face
 
   ! intrinsics
 ! ^^^^^^^^^^^^ font-lock-comment-face
@@ -204,11 +207,10 @@
 !                                ^ f90-ts-font-lock-delimiter-face
 !                                  ^^^^^^^^^^ font-lock-builtin-face
 !                                            ^^ f90-ts-font-lock-bracket-face
-  end change team name_ch
+  end team name_ch
 ! ^^^ font-lock-keyword-face
-!     ^^^^^^ font-lock-keyword-face
-!            ^^^^ font-lock-keyword-face
-!                 ^^^^^^^ nil
+!     ^^^^ font-lock-keyword-face
+!          ^^^^^^^ nil
 
  end program coarray_test
 !^^^ font-lock-keyword-face

--- a/test/resources/indent_region_coarray.erts
+++ b/test/resources/indent_region_coarray.erts
@@ -1,0 +1,198 @@
+Point-Char: |
+
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (when f90-ts-mode-test--prepare-fn
+      (funcall f90-ts-mode-test--prepare-fn))
+    (funcall f90-ts-mode-test--action-fn))
+
+Name: coarray 1
+=-=
+program coarray_test
+ use iso_fortran_env
+ implicit none
+
+ integer :: scalar_co[*]
+ real    :: arr(10)[2, *]
+ real, codimension[2,*], allocatable :: arr2(10)
+ real, dimension(1:10), codimension[1:2,*], pointer :: arr3
+ integer, codimension[1:3,1:4,*] :: val
+ type(team_type) :: team_value
+ type(lock_type), codimension[*] :: mylock
+
+ scalar_co[1]      = 42
+ arr(5)[1, 2]      = 3.14
+ val[this_image()] = this_image()
+
+ ! intrinsics
+ print *, num_images()
+ print *, this_image()
+ print *, image_index(arr, [1, 2])
+
+ ! synchronization
+ sync all
+ sync images(*)
+ sync images([1, 2, 3])
+ sync memory
+
+ ! critical section
+ name_crit: critical
+      scalar_co[1] = scalar_co[1] + 1
+ end critical name_crit
+
+ ! team
+ form team (mod(this_image(), 2) + 1, team_value)
+ name_ch: change team (team_value)
+      print *, "in team, image:", this_image()
+ end team name_ch
+
+end program coarray_test
+=-=-=
+
+Name: coarray 2
+=-=
+program sum_square
+ use, intrinsic :: iso_fortran_env, only: lock_type
+ use iso_fortran_env, only : STAT_FAILED_IMAGE,  STAT_STOPPED_IMAGE
+
+ implicit none
+ type(lock_type), codimension[*] :: slock
+ integer, codimension[*] :: ssq
+ integer :: sync_stat, alloc_stat
+
+ if (this_image() == 1) then
+      i = 1
+ end if
+ sync all (stat=sync_stat)
+ if (stat /= 0) then
+      if (stat == STAT_FAILED_IMAGE) then
+           print *,"Failed images: ", failed_images()
+      else if (stat == STAT_STOPPED_IMAGE) then
+           print *,"Stopped images: ", stopped_images()
+      else
+           print *,"Unforseen error, aborting"
+           error stop
+      end if
+ end if
+
+ block
+      logical :: gotit
+      do
+           lock(slock[1], acquired_lock=gotit)
+           if (gotit) exit
+      end do
+ end block
+ ssq[1] = this_image()**2 + ssq[1]
+ unlock (slock[1])
+ call co_broadcast(ssq, 1)
+ print *, this_image(), ssq
+
+ ssq = this_image()**2
+ call co_sum(ssq, result_image=1)
+ call co_min(ssq)
+ call co_max(ssq)
+ call co_reduce(ssq, redfun)
+
+ print *, this_image(), co_min(ssq), co_max(ssq)
+ if (this_image() == 1) then
+      print *, this_image(), co_sum(ssq, result_image=1)
+ end if
+end program sum_square
+=-=-=
+
+Name: coarray 3
+=-=
+program event_with_wait
+ use iso_fortran_env, only: event_type
+ implicit none
+
+ type(event_type) :: evt[*]
+ integer :: me
+
+ me = this_image()
+
+ if (num_images() < 2) then
+      if (me == 1) print *, "Run with at least 2 images"
+      stop
+ end if
+
+ if (me == 1) then
+      print *, "image 1 waiting for TWO events..."
+
+      ! Wait until at least 2 events have been posted
+      call event_wait(evt, until_count=2)
+
+      print *, "image 1 received 2 events!"
+
+ else if (me == 2) then
+      print *, "image 2 posting events..."
+
+      call event_post(evt[1])
+      print *, "Posted first event"
+
+      call event_post(evt[1])
+      print *, "Posted second event"
+ end if
+
+end program event_with_wait
+=-=-=
+
+Name: coarray 4
+=-=
+program fail_atom_event_example
+ use iso_fortran_env, only: event_type, atomic_int_kind
+ implicit none
+
+ type(event_type) :: evt[*]
+ integer(atomic_int_kind) :: flag[*]   ! shared atomic flag
+ integer :: me, val
+ logical :: done
+
+ me = this_image()
+
+ if (num_images() < 2) then
+      if (me == 1) print *, "Run with at least 2 images"
+      stop
+ end if
+
+ if (me == 2) then
+      ! producer (image 2)
+      print *, "image 2: starting work"
+
+      call atomic_define(flag[1], 42)
+      print *, "image 2: wrote value"
+
+      call event_post(evt[1])
+      print *, "image 2: notified image 1"
+
+      ! simulate failure after notifying
+      print *, "image 2: failing now"
+      fail image
+
+ else if (me == 1) then
+      ! consumer (image 1)
+      print *, "image 1: waiting for notification..."
+
+      done = .false.
+
+      do while (.not. done)
+           ! wait for event (may return even if image 2 later fails)
+           call event_wait(evt)
+
+           ! check if image 2 is still alive
+           if (this_image() /= 2 .and. failed_images() /= 0) then
+                print *, "image 1: detected a failed image"
+           end if
+
+           ! safely read atomic value
+           call atomic_ref(val, flag)
+
+           print *, "image 1: received value =", val
+           done = .true.
+
+      end do
+ end if
+
+end program fail_atom_event_example
+=-=-=


### PR DESCRIPTION
Fix smart end completion for coarray "end team" statements

Properly form the "end team" statement for an "change team ... end team" block.
It was wrongly assumed that the end statement is "end change team".