### PR TITLE
Remove leading blanks in f90-ts--fontify-error

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ For a comprehensive overview see [MANUAL.md](MANUAL.md).
 ### Recently added, changed or improved
 
 **08-2026**
- - Add About, README and MANUAL entries in the fortran and transient
-   popup menu to view information about the mode.
+ - About, README and MANUAL entries in the fortran and transient
+   popup menu to view information about the mode added.
  - Additional font-locking for error regions added.  This can be customized by
    `f90-ts-font-lock-error' and `f90-ts-font-lock-error-face'.
  - Smart end completion of coarray "change team ... end team" blocks fixed. It was

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -1090,6 +1090,21 @@ located, otherwise return line number of current point position."
     (point)))
 
 
+(defun f90-ts--node-span-trimmed (node)
+  "Return the trimmed span of NODE as cons cell (START . END).
+The trimmed span starts at the first non-blank character
+and ends at the last non-blank character of NODE."
+  (save-excursion
+    (cons (progn
+            (goto-char (treesit-node-start node))
+            (skip-chars-forward " \t\n\r\f")
+            (point))
+          (progn
+            (goto-char (treesit-node-end node))
+            (skip-chars-backward " \t\n\r\f")
+            (point)))))
+
+
 (defun f90-ts--empty-comment-node-p (node)
   "Return non-nil if comment NODE has no content after its prefix."
   (and (f90-ts--node-type-p node "comment")
@@ -2125,19 +2140,15 @@ error node has descendant, then the function appends
 `f90-ts-font-lock-error-face' to existing font-lock face.
 Often an error results in several \"ERROR\" nodes in the chain towards the root.
 Only the smallest error nodes should be marked.  Moreover, the span is trimmed
-to exclude trailing blanks, which are sometimes part of more complex nodes."
+to exclude leading and trailing blanks, which are sometimes part of ERROR nodes."
   (when (and f90-ts-font-lock-error
              (let ((sparse-tree (treesit-induce-sparse-tree node "^ERROR$")))
                ;; if the sparse-tree has only one node (node itself),
                ;; it has the shape "(nil (node))"
                (and (= (length (cdr sparse-tree)) 1)
                     (null (cdr (cadr sparse-tree))))))
-    (let ((start (treesit-node-start node))
-           (end (save-excursion
-                  ;; trim trailing blanks
-                  (goto-char (treesit-node-end node))
-                  (skip-chars-backward " \t\n\r\f")
-                  (point))))
+
+    (cl-destructuring-bind (start . end) (f90-ts--node-span-trimmed node)
       (treesit-fontify-with-override start end
                                      f90-ts-font-lock-error
                                      'append))))

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -32,15 +32,18 @@
 ;; files, based on Emacs's built-in tree-sitter support (requires Emacs 30+)
 ;;
 ;; Recently changed, added or improved:
-;;   [08-2026] Add About, README and MANUAL entries in the fortran and transient
-;;             popup menu to view information about the mode.
+;;   [08-2026] About, README and MANUAL entries in the fortran and transient
+;;             popup menu to view information about the mode added.
 ;;   [08-2026] Additional font-locking for error regions added.  This can be
-;;             customized by `f90-ts-font-lock-error' and `f90-ts-font-lock-error-face'.
-;;   [08-2026] Smart end completion of coarray "change team ... end team" blocks fixed.
-;;             It was wrongly assumed that the end statement is "end change team".
+;;             customized by `f90-ts-font-lock-error' and
+;;             `f90-ts-font-lock-error-face'.
+;;   [08-2026] Smart end completion of coarray "change team ... end team"
+;;             blocks fixed.  It was wrongly assumed that the end statement is
+;;             "end change team".
 ;;
 ;;   [07-2026] Inherit attribute of some font lock faces fixed.
-;;   [07-2026] Alignment of unary expressions with leading minus or plus improved.
+;;   [07-2026] Alignment of unary expressions with leading minus or plus
+;;             improved.
 ;;
 ;;   [06-2026] Fill line and region operations added.
 ;;   [06-2026] Defcustom group f90-ts-comment added.
@@ -133,8 +136,8 @@ source files, based on Emacs's built-in tree-sitter support
 Recently changed, added or improved:
 
 [08-2026]
-- Add About, README and MANUAL entries in the fortran menu
-  to view information about the mode.
+- About, README and MANUAL entries in the fortran and transient
+  popup menu to view information about the mode added.
 - Additional font-locking for error regions added.  This can be
   customized by `f90-ts-font-lock-error' and
   `f90-ts-font-lock-error-face'.

--- a/test/resources/font_lock_error.f90
+++ b/test/resources/font_lock_error.f90
@@ -39,6 +39,32 @@
 
 
  subroutine error3()
+!^^^^^^^^^^ font-lock-keyword-face
+!           ^^^^^^ font-lock-function-name-face
+!                 ^^ f90-ts-font-lock-bracket-face
+
+ contains
+!^^^^^^^^ font-lock-keyword-face
+
+    ! comment
+!   ^^^^^^^^^ font-lock-comment-face
+
+    sfunction f()
+!   ^ (f90-ts-font-lock-error-face)
+!    ^^^^^^^^ font-lock-keyword-face
+!             ^ font-lock-function-name-face
+!              ^^ f90-ts-font-lock-bracket-face
+     end function f
+!    ^^^ font-lock-keyword-face
+!        ^^^^^^^^ font-lock-keyword-face
+!                 ^ font-lock-function-name-face
+
+ end subroutine error3
+!^^^ font-lock-keyword-face
+!    ^^^^^^^^^^ font-lock-keyword-face
+!               ^^^^^^ font-lock-function-name-face
+
+ subroutine error4()
 !^^^^^^^^^^ (font-lock-keyword-face f90-ts-font-lock-error-face)
 !          ^ (f90-ts-font-lock-error-face)
 !           ^^^^^^ (font-lock-function-name-face f90-ts-font-lock-error-face)


### PR DESCRIPTION
Remove leading blanks in f90-ts--fontify-error to improve the error span.