### PR TITLE
Fix mark region operations for nodes with non-trimmed span

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ For a comprehensive overview see [MANUAL.md](MANUAL.md).
 ### Recently added, changed or improved
 
 **08-2026**
+ - Mark region operations fixed: always consider trimmed region of nodes.
+   Some nodes like a whole `subroutine..end subroutine` block contains a trailing
+   newline, which should not be considered. Not consequently trimming all spans
+   broke some mark region operations.
  - About, README and MANUAL entries in the fortran and transient
    popup menu to view information about the mode added.
  - Additional font-locking for error regions added.  This can be customized by
@@ -198,8 +202,16 @@ The following list provides features planned for implementation (somewhat ordere
 - Fill operations with lower column width (before joining).
 - Fill operation similar to `f90-fill-paragraph`. In conjunction with mark operations: determine interesting
   nodes within tree as region (like: statements, structure block, subroutine/function level).
+- Node based sibling walk operations (like goto trimmed beginning or trimmed end of next sibling). This would
+  complement the mark region operations to easily extend an existing region.
 - Support for (context-aware) `completion-at-point-function` (capf).
 - More list contexts for alignment in continued lines.
   There are a number of list like contexts, which are not yet supported, but for which proper
   alignment would be nice.
 - Electric insert similar to `f90-electric-insert`.
+- Indentation for labeled do loops, like:
+  do 123 i = 1,10
+     do 123 j = 1,10
+        print *, i, j
+  123 end do
+  (Remark: the end do statement has one real and one virtual node to match the number of nested loops.)

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -32,6 +32,11 @@
 ;; files, based on Emacs's built-in tree-sitter support (requires Emacs 30+)
 ;;
 ;; Recently changed, added or improved:
+;;   [08-2026] Mark region operations fixed: always consider trimmed region
+;;             of nodes.  Some nodes like a whole "subroutine..end subroutine"
+;;             block contains a trailing newline, which should not be
+;;             considered.  Not consequently trimming all spans broke some mark
+;;             region operations.
 ;;   [08-2026] About, README and MANUAL entries in the fortran and transient
 ;;             popup menu to view information about the mode added.
 ;;   [08-2026] Additional font-locking for error regions added.  This can be
@@ -136,6 +141,11 @@ source files, based on Emacs's built-in tree-sitter support
 Recently changed, added or improved:
 
 [08-2026]
+- Mark region operations fixed: always consider trimmed region
+  of nodes. Some nodes like a whole `subroutine..end subroutine`
+  block contains a trailing newline, which should not be
+  considered. Not consequently trimming all spans broke some mark
+  region operations.
 - About, README and MANUAL entries in the fortran and transient
   popup menu to view information about the mode added.
 - Additional font-locking for error regions added.  This can be
@@ -6942,8 +6952,9 @@ If NAMED is non-nil, consider only named nodes."
   (when-let* ((node (f90-ts--node-on-pos beg 'right named)))
     (treesit-parent-while
      node
-     (lambda (n) (and (=  beg (f90-ts--node-start-trimmed n))
-                      (<= (treesit-node-end n) end))))))
+     (lambda (n)
+       (and (=  beg (f90-ts--node-start-trimmed n))
+            (<= (f90-ts--node-end-trimmed n) end))))))
 
 
 (defun f90-ts--node-aligned-at-end (beg end named)
@@ -6952,14 +6963,15 @@ If NAMED is non-nil, consider only named nodes."
   (when-let* ((node (f90-ts--node-on-pos end 'left named)))
     (treesit-parent-while
      node
-     (lambda (n) (and (<= beg (treesit-node-start n))
-                      (= (f90-ts--node-end-trimmed n) end))))))
+     (lambda (n)
+       (and (<= beg (f90-ts--node-start-trimmed n))
+            (= (f90-ts--node-end-trimmed n) end))))))
 
 
 (defun f90-ts--group-block-p (node-beg node-end)
   "Check whether NODE-BEG and NODE-END are within a node group.
-This is the case if both are sibling (have the same parent),
-belong to the same group, and all sibling in between the two
+This is the case if both are siblings (have the same parent),
+belong to the same group, and all siblings in between the two
 nodes also belong to the same group."
   (and node-beg
        node-end

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -6884,18 +6884,26 @@ is at end of region."
     (f90-ts--mark-region-node node-or-extent region-order)))
 
 
-(defun f90-ts--smallest-named-node-containing-region (beg end)
+(defun f90-ts--smallest-named-node-containing-region (beg end trim)
   "Return the smallest named node fully containing region from BEG to END.
-The node must be strictly larger than the region (BEG END)."
+The node must be strictly larger than the region (BEG END).
+If TRIM is non-nil, then use trimmed span of named nodes for comparison
+with BEG..END region."
   (when-let* ((node (treesit-node-on beg end))
               (cover (treesit-parent-until
                       node
                       (lambda (n)
-                        (and (treesit-node-check n 'named)
-                             (<= (treesit-node-start n) beg)
-                             (>= (treesit-node-end n) end)
-                             (< (- end beg)
-                                (- (treesit-node-end n) (treesit-node-start n)))))
+                        (let ((nb (if trim
+                                      (f90-ts--node-start-trimmed n)
+                                    (treesit-node-start n)))
+                              (ne (if trim
+                                      (f90-ts--node-end-trimmed n)
+                                    (treesit-node-end n))))
+                          (and (treesit-node-check n 'named)
+                               (<= nb beg)
+                               (>= ne end)
+                               (< (- end beg)
+                                  (- ne nb)))))
                       t)))
     (f90-ts--largest-node-same-span cover)))
 
@@ -7034,13 +7042,13 @@ If at least one group is nil, return value is nil as well."
                  (ext-last  (cdr extent)))
             (if (treesit-node-eq ext-first ext-last)
                 ;; block is just one line, fall through to tree-sitter ascent
-                (if-let ((node (f90-ts--smallest-named-node-containing-region beg end)))
+                (if-let ((node (f90-ts--smallest-named-node-containing-region beg end 'trim)))
                     (f90-ts--mark-region-node node f90-ts-mark-region-order)
                   (message "no tree-sitter node found enlarging current region"))
               (f90-ts--mark-region (f90-ts--node-start-trimmed ext-first)
                                    (f90-ts--node-end-trimmed   ext-last)
                                    f90-ts-mark-region-order)))
-        (if-let ((node (f90-ts--smallest-named-node-containing-region beg end)))
+        (if-let ((node (f90-ts--smallest-named-node-containing-region beg end 'trim)))
             (f90-ts--mark-region-node node f90-ts-mark-region-order)
           (message "no tree-sitter node found enlarging current region"))))))
 

--- a/test/resources/mark_region.erts
+++ b/test/resources/mark_region.erts
@@ -180,6 +180,32 @@ subroutine sub_ext_3()
 end subroutine sub_ext_3
 =-=-=
 
+Name: mark extend enlarge region 4
+=-=
+module mod_ext_4
+
+use other
+
+contains
+
+|subroutine sub()@
+   call something()
+end subroutine sub
+
+end module mod_ext_4
+=-=
+module mod_ext_4
+
+use other
+
+contains
+
+|subroutine sub()
+   call something()
+end subroutine sub@
+
+end module mod_ext_4
+=-=-=
 
 Code:
   (lambda ()
@@ -189,13 +215,13 @@ Code:
 
 Name: mark extend enlarge region 5
 =-=
-subroutine sub_ext_4()
+subroutine sub_ext_5()
   @print *,'hello'|
-end subroutine sub_ext_4
+end subroutine sub_ext_5
 =-=
-|subroutine sub_ext_4()
+|subroutine sub_ext_5()
   print *,'hello'
-end subroutine sub_ext_4@
+end subroutine sub_ext_5@
 =-=-=
 
 
@@ -205,15 +231,15 @@ Code:
     (let ((f90-ts-mark-region-order 'preserve))
       (f90-ts-mode-test--mark-region-modify #'f90-ts-mark-region-enlarge)))
 
-Name: mark extend enlarge region 5
+Name: mark extend enlarge region 6
 =-=
-subroutine sub_ext_5()
+subroutine sub_ext_6()
   |print *,'hello'@
-end subroutine sub_ext_5
+end subroutine sub_ext_6
 =-=
-|subroutine sub_ext_5()
+|subroutine sub_ext_6()
   print *,'hello'
-end subroutine sub_ext_5@
+end subroutine sub_ext_6@
 =-=-=
 
 Code:

--- a/test/resources/mark_region.erts
+++ b/test/resources/mark_region.erts
@@ -358,6 +358,50 @@ subroutine sub_first_1()
 end subroutine sub_first_1
 =-=-=
 
+Name: mark first region 2
+=-=
+module mod
+
+use other
+
+! note that the grammar places contains as a sibling of its follow content
+contains
+
+subroutine sub1()
+end subroutine sub1
+
+subroutine sub2()
+end subroutine sub2
+
+|subroutine sub3()
+end subroutine sub3@
+
+subroutine sub4()
+end subroutine sub4
+
+end module mod
+=-=
+module mod
+
+use other
+
+! note that the grammar places contains as a sibling of its follow content
+|contains@
+
+subroutine sub1()
+end subroutine sub1
+
+subroutine sub2()
+end subroutine sub2
+
+subroutine sub3()
+end subroutine sub3
+
+subroutine sub4()
+end subroutine sub4
+
+end module mod
+=-=-=
 
 Code:
   (lambda ()
@@ -379,6 +423,92 @@ subroutine sub_prev_1()
       end do|
    end if
 end subroutine sub_prev_1
+=-=-=
+
+Name: mark prev region 2
+=-=
+module mod
+
+use other
+
+contains
+
+subroutine sub2()
+   call other()
+   if (cond1) then
+      call action1()
+   end if
+   |if (cond2) then
+      call action2()
+   end if@
+end subroutine sub2
+
+end module mod
+=-=
+module mod
+
+use other
+
+contains
+
+subroutine sub2()
+   call other()
+   |if (cond1) then
+      call action1()
+   end if@
+   if (cond2) then
+      call action2()
+   end if
+end subroutine sub2
+
+end module mod
+=-=-=
+
+Name: mark prev region 3
+=-=
+module mod
+
+use other
+
+contains
+
+subroutine sub1()
+   call something()
+end subroutine sub1
+
+|subroutine sub2()
+   call other()
+   if (cond1) then
+      call action1()
+   end if
+   if (cond2) then
+      call action2()
+   end if
+end subroutine sub2@
+
+end module mod
+=-=
+module mod
+
+use other
+
+contains
+
+|subroutine sub1()
+   call something()
+end subroutine sub1@
+
+subroutine sub2()
+   call other()
+   if (cond1) then
+      call action1()
+   end if
+   if (cond2) then
+      call action2()
+   end if
+end subroutine sub2
+
+end module mod
 =-=-=
 
 Name: mark prev region group 1
@@ -634,6 +764,92 @@ subroutine sub_next_1()
 end subroutine sub_next_1
 =-=-=
 
+Name: mark next region 2
+=-=
+module mod
+
+use other
+
+contains
+
+subroutine sub2()
+   call other()
+   |if (cond1) then
+      call action1()
+   end if@
+   if (cond2) then
+      call action2()
+   end if
+end subroutine sub2
+
+end module mod
+=-=
+module mod
+
+use other
+
+contains
+
+subroutine sub2()
+   call other()
+   if (cond1) then
+      call action1()
+   end if
+   |if (cond2) then
+      call action2()
+   end if@
+end subroutine sub2
+
+end module mod
+=-=-=
+
+Name: mark next region 3
+=-=
+module mod
+
+use other
+
+contains
+
+|subroutine sub1()
+   call something()
+end subroutine sub1@
+
+subroutine sub2()
+   call other()
+   if (cond1) then
+      call action1()
+   end if
+   if (cond2) then
+      call action2()
+   end if
+end subroutine sub2
+
+end module mod
+=-=
+module mod
+
+use other
+
+contains
+
+subroutine sub1()
+   call something()
+end subroutine sub1
+
+|subroutine sub2()
+   call other()
+   if (cond1) then
+      call action1()
+   end if
+   if (cond2) then
+      call action2()
+   end if
+end subroutine sub2@
+
+end module mod
+=-=-=
+
 Name: mark next region group 1
 =-=
 ! recognise comment block as virtual node
@@ -878,6 +1094,49 @@ subroutine sub_last_1()
       end do
    @end if|
 end subroutine sub_last_1
+=-=-=
+
+Name: mark last region 2
+=-=
+module mod
+
+use other
+
+contains
+
+subroutine sub1()
+end subroutine sub1
+
+|subroutine sub2()
+end subroutine sub2@
+
+subroutine sub3()
+end subroutine sub3
+
+subroutine sub4()
+end subroutine sub4
+
+end module mod
+=-=
+module mod
+
+use other
+
+contains
+
+subroutine sub1()
+end subroutine sub1
+
+subroutine sub2()
+end subroutine sub2
+
+subroutine sub3()
+end subroutine sub3
+
+|subroutine sub4()
+end subroutine sub4@
+
+end module mod
 =-=-=
 
 Code:


### PR DESCRIPTION
Fix mark region operations for nodes with non-trimmed span. Such nodes starts before first non-blank character (only ERROR is know to have this) or end after last non-blank character (like subroutine blocks, which contain their end-of-statement newline token).
Proper test cases were missing, so that the trimming of regions introduced some time ago, broke region operations for such non-trimmed nodes.