### PR TITLE
Fix an infinite loop in f90-ts-complete-smart-end-region

### DIFF
--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -5711,8 +5711,14 @@ no abort mechanism for `treesit-search-foward'."
              do (let ((node-start (treesit-node-start node)))
                   (f90-ts--complete-smart-end-node node)
                   (goto-char node-start)
-                  (forward-line 1)
-                  (setq pos (point)))))
+                  (let ((line (line-number-at-pos)))
+                    ;; that a bit difficult, if at end of buffer, `forward-line'
+                    ;; does not progress a line, but still reports success, so we
+                    ;; explicitly check line numbers
+                    (forward-line 1)
+                    (if (= line (line-number-at-pos))
+                        (throw 'f90-ts--past-end nil)
+                      (setq pos (point)))))))
           ;; after finishing move to end of region
           (goto-char end-marker))
       (set-marker end-marker nil))))

--- a/test/resources/indent_stmt_misc.erts
+++ b/test/resources/indent_stmt_misc.erts
@@ -321,3 +321,23 @@ contains
  end subroutine simulate|
 end
 =-=-=
+
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (delete-region (point) (point-max))
+    (f90-ts-indent-and-complete-stmt)
+    (insert "\n")
+    (goto-char (1- (point))))
+
+Name: completion at end of buffer without final newline
+
+=-=
+subroutine sub()
+     name: if (cond) then
+     end|
+=-=
+subroutine sub()
+     name: if (cond) then
+     end if name|
+=-=-=


### PR DESCRIPTION
Fix an infinite loop in smart end completion at the last line without a final newline. In that case (forward-line 1) in the region loop does not progress and the function gets stuck in an infinite loop.
