### PR TITLE
Fix indentation issues with continuation right after a block label statement

### DIFF
--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -4468,15 +4468,17 @@ This is the maximal node for any further subtree searches."
   (let* ((pos (alist-get 'pos loc))
          (line (alist-get 'line loc))
          (ps-key (f90-ts--indent-prev-stmt-keyword))
-         (stmt-root (treesit-node-on (treesit-node-start ps-key)
-                                     pos)))
-    (treesit-search-subtree
-     stmt-root
-     (lambda (n)
-       (and (<= (f90-ts--node-line n) line)
-            (<= line (line-number-at-pos (treesit-node-end n)))
-            (assoc (treesit-node-type n)
-                   f90-ts--align-list-context-properties))))))
+         (stmt-beg (treesit-node-start ps-key))
+         (stmt-root (when (<= stmt-beg pos)
+                      (treesit-node-on (treesit-node-start ps-key) pos))))
+    (when stmt-root
+      (treesit-search-subtree
+       stmt-root
+       (lambda (n)
+         (and (<= (f90-ts--node-line n) line)
+              (<= line (line-number-at-pos (treesit-node-end n)))
+              (assoc (treesit-node-type n)
+                     f90-ts--align-list-context-properties)))))))
 
 
 (defun f90-ts--align-list-context-op-expr (loc parent)

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -1951,13 +1951,13 @@ This might be a \"block_label_start_expression\", which needs to be skipped.
 
 Auxiliary function for `f90-ts--previous-stmt-keyword' or when
 first statement is known."
-  (if-let ((block-label (f90-ts--node-block-label-ancestor first)))
-	  (let ((fp-next (treesit-node-next-sibling block-label)))
-        (cl-loop
-         for n = fp-next then child
-         for child = (treesit-node-child n 0)
-         while child
-         finally return n))
+  (if-let* ((block-label (f90-ts--node-block-label-ancestor first))
+	        (next (f90-ts--skip-continuation-forward block-label)))
+      (cl-loop
+       for n = next then child
+       for child = (treesit-node-child n 0)
+       while child
+       finally return n)
     ;; not a label expression, just return first
     first))
 

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -1749,33 +1749,67 @@ Take virtual ampersand nodes into account, these are not returned by
           node)))))
 
 
-(defun f90-ts--find-first-ampersand (first)
-  "Find the first ampersand if at a ampersand-comment*-ampersand sequence.
+(defun f90-ts--skip-comments-to-ampersand (node sibling-fn)
+  "Return final ampersand after a sequence of comment nodes.
+Walk from NODE via SIBLING-FN across comment nodes, and return
+the ampersand node reached once comments end.  Return nil if NODE
+is nil, not a comment, or if the node reached after skipping comments
+is not an ampersand."
+  (cl-loop for n = node then (funcall sibling-fn n)
+           while (f90-ts--node-type-p n "comment")
+           finally return (and (f90-ts--node-ampersand-p n) n)))
+
+
+(defun f90-ts--find-ampersand-boundary (node sibling-fn)
+  "Find the ampersand at the far end of an &-comment*-& sequence.
+
+Walking siblings is done via SIBLING-FN, which determines the direction of
+the walk \(`treesit-node-prev-sibling' or `treesit-node-next-sibling'\).
+
+If NODE is an ampersand or a comment that is part of such a sequence, return
+the ampersand at the far end of it.  Otherwise, including if NODE is
+of any other type, return nil."
+  (cond
+   ((f90-ts--node-ampersand-p node)
+    ;; try to skip subsequent comments, otherwise return node,
+    ;; which is already the boundary ampersand
+    (or (f90-ts--skip-comments-to-ampersand
+         (funcall sibling-fn node) sibling-fn)
+        node))
+   ((f90-ts--node-type-p node "comment")
+    (f90-ts--skip-comments-to-ampersand node sibling-fn))
+   (t nil)))
+
+
+(defun f90-ts--sibling-skip-continuation (node sibling-fn)
+  "Return NODE's sibling, skipping a &-comment*-& sequence if present.
+
+Walking siblings is done via SIBLING-FN, which determines the direction of
+the walk \(`treesit-node-prev-sibling' or `treesit-node-next-sibling'\).
+
+If sibling of NODE is an ampersand or comment that is part of such a sequence,
+return the node directly following the sequence's second ampersand (nil if
+there is no such sibling).  Otherwise return the sibling of NODE itself."
+  (when-let ((nsib (funcall sibling-fn node)))
+    (if-let ((amp2 (f90-ts--find-ampersand-boundary
+                    nsib #'treesit-node-next-sibling)))
+        (treesit-node-next-sibling amp2)
+      nsib)))
+
+
+(defun f90-ts--skip-continuation-forward (node)
+  "Return NODE's next sibling, skipping a &-comment*-& sequence if present.
+See `f90-ts--sibling-skip-continuation'."
+  (f90-ts--sibling-skip-continuation node #'treesit-node-next-sibling))
+
+
+(defun f90-ts--find-first-ampersand (node)
+  "Find the first ampersand if at a &-comment*-& sequence.
 In continued lines, continuation symbol ampersands appears in
-sequences like &, (comment)*, &.  This routines checks whether node
-FIRST is any of those ampersand or comment nodes, and returns the first
-ampersand node of this sequence.  FIRST is assumed to be the first node
-on its line!"
-  (when-let ((nprev
-              (cond
-               ((f90-ts--node-ampersand-p first)
-                ;; go one step back to first ampersand or sequence
-                ;; of comments
-                (treesit-node-prev-sibling first))
-
-               ((f90-ts--node-type-p first "comment")
-                first)
-
-               (t
-                ;; in all other cases, we are not on a continued line
-                nil))))
-    ;; if necessary skip comments (but only comments) to find the first ampersand,
-    ;; if we are in a sequence of comments not being part of a continued line,
-    ;; then the final non-comment node is not an ampersand and we return nil
-    (cl-loop for node = nprev then (treesit-node-prev-sibling node)
-             while (f90-ts--node-type-p node "comment")
-             finally return (and (f90-ts--node-ampersand-p node)
-                                 node))))
+sequences like &, (comment)*, &.  This routines checks whether NODE
+is any of those ampersand or comment nodes, and returns the first
+ampersand node of this sequence."
+  (f90-ts--find-ampersand-boundary node #'treesit-node-prev-sibling))
 
 
 (defun f90-ts--first-node-of-stmt (node)

--- a/f90-ts-mode.el
+++ b/f90-ts-mode.el
@@ -1346,6 +1346,45 @@ Note that the parse uses identifier not just for variables, but for types etc."
                     (treesit-node-text node))))
 
 
+(defun f90-ts--node-block-label-ancestor (node)
+  "Return block_label_start_expression ancestor of leaf NODE if there is one.
+NODE is assumed to be the leaf node at the start of a line.  The function
+checks whether it is part of a \"block_label_start_expression\"."
+  ;; Unfortunately, this comes in two variants (as a label name, which is a language
+  ;; keyword parses slightly differently):
+  ;;
+  ;;   (block_label_start_expression
+  ;;    'label'
+  ;;    :)
+  ;;
+  ;; and if the label is a reserved keyword:
+  ;;
+  ;;   (block_label_start_expression
+  ;;    'label'
+  ;;     keyword
+  ;;    :)
+  ;;
+  ;; In both cases, 'label' is an anonymous node.  In the second case, it has the
+  ;; child keyword.
+  ;; In any case, the function should return \"block_label_start_expression\",
+  ;; or nil.
+  (cl-assert (or (not node)
+                 (zerop (treesit-node-child-count node nil)))
+             nil "node is not a leaf node: %s" node)
+  (let* ((parent (and node (treesit-node-parent node)))
+         (grandparent (and parent (treesit-node-parent parent))))
+    (cond
+     ((and (f90-ts--node-type-p node "label")
+           (f90-ts--node-type-p parent
+                                "block_label_start_expression"))
+      parent)
+     ((and (f90-ts--node-type-p parent "label")
+           (f90-ts--node-type-p grandparent
+                                "block_label_start_expression"))
+      grandparent)
+     (t nil))))
+
+
 (defun f90-ts--node-preproc-p (node)
   "Check if NODE is a preprocessor node and has the '#' prefix."
     (let ((type (treesit-node-type node)))
@@ -1908,59 +1947,19 @@ example on empty lines)."
 (defun f90-ts--previous-stmt-keyword-by-first (first)
   "Return keyword of previous statement.
 Use node FIRST which provides the very first leaf node of previous statement.
+This might be a \"block_label_start_expression\", which needs to be skipped.
+
 Auxiliary function for `f90-ts--previous-stmt-keyword' or when
 first statement is known."
-  ;; block structure statements like if, do, associate etc. can start
-  ;; with a label, if a (optional) label is present, skip it and extract
-  ;; the keyword node;
-  ;; in general, the AST looks like:
-  ;;
-  ;; (do_loop
-  ;;  (block_label_start_expression
-  ;;   'label'
-  ;;   :)
-  ;;  (do_statement do
-  ;;  ...))
-  ;;
-  ;; but if label is a reserved keyword, it becomes
-  ;;
-  ;; (do_loop
-  ;;  (block_label_start_expression
-  ;;   'label'
-  ;;    keyword
-  ;;   :)
-  ;;  (do_statement do
-  ;;  ...))
-  ;;
-  ;; in both cases 'label' is an anonymous node;
-  ;; in the second case, it has a child,
-  ;;
-  ;; we want to extract the anonymous node "do" of the statement
-  ;; following the block_label_start expression,
-  ;; so first check we are within a block_label_start_expression
-  (let* ((parent (and first (treesit-node-parent first)))
-         (grandparent (and parent (treesit-node-parent parent)))
-         (block-label (cond
-                       ((and (f90-ts--node-type-p first "label")
-                             (f90-ts--node-type-p parent
-                                                  "block_label_start_expression"))
-                        parent)
-                       ((and (f90-ts--node-type-p parent "label")
-                             (f90-ts--node-type-p grandparent
-                                                  "block_label_start_expression"))
-                      grandparent)
-                       (t nil))))
-    (if block-label
-	    (let ((fp-next (treesit-node-next-sibling block-label)))
-          ;; next sibling is a statement label, we descend to find
-          ;; first leaf
-          (cl-loop
-           for n = fp-next then child
-           for child = (treesit-node-child n 0)
-           while child
-           finally return n))
-      ;; not a label expression, just return first
-      first)))
+  (if-let ((block-label (f90-ts--node-block-label-ancestor first)))
+	  (let ((fp-next (treesit-node-next-sibling block-label)))
+        (cl-loop
+         for n = fp-next then child
+         for child = (treesit-node-child n 0)
+         while child
+         finally return n))
+    ;; not a label expression, just return first
+    first))
 
 
 (defun f90-ts--previous-stmt-keyword (node parent)

--- a/test/f90-ts-mode-test.el
+++ b/test/f90-ts-mode-test.el
@@ -926,6 +926,7 @@ If buffer was modified, insert `**' otherwise insert '--'."
    "indent_region_preproc.erts"
    "indent_region_openmp.erts"
    "indent_region_coarray.erts"
+   "indent_region_block_label.erts"
    "indent_region_stmt_label.erts")
  '(nil ; no modification
    f90-ts-mode-test--remove-indent

--- a/test/resources/indent_region_block_label.erts
+++ b/test/resources/indent_region_block_label.erts
@@ -1,0 +1,40 @@
+Code:
+  (lambda ()
+    (f90-ts-mode)
+    (when f90-ts-mode-test--prepare-fn
+      (funcall f90-ts-mode-test--prepare-fn))
+    (funcall f90-ts-mode-test--action-fn))
+
+Point-Char: |
+
+Name: block label 1
+=-=
+subroutine sub()
+     inc: associate (x => array(i))
+          x = x + 1
+     end associate inc
+
+     name: do while (cond)
+          x = x + 1
+     end do name
+
+     if: if (cond) then
+          x = x + 1
+     end if if
+end subroutine sub
+=-=-=
+
+Name: block label with continuation 1
+=-=
+subroutine sub()
+     inc: &
+            associate (x => array(i))
+          x = x + 1
+     end associate inc
+
+     name: & ! comment
+            do while (cond)
+          x = x + 1
+     end do name
+end subroutine sub
+=-=-=

--- a/test/resources/indent_region_block_label.erts
+++ b/test/resources/indent_region_block_label.erts
@@ -36,5 +36,20 @@ subroutine sub()
             do while (cond)
           x = x + 1
      end do name
+
+     select_x: &
+            ! comment
+            select case (x)
+     case (1)
+          print *, 'hallo'
+     end select select_x
+
+     if: &
+            ! several comments
+            ! several comments
+            ! several comments
+            if (cond) then
+          x = x + 1
+     end if if
 end subroutine sub
 =-=-=


### PR DESCRIPTION
Fix indentation issues with continuation right after a block label statement, such as in:
```
subroutine sub()
     inc: &
            associate (x => array(i))
          x = x + 1
     end associate inc

     name: & ! comment
            do while (cond)
          x = x + 1
     end do name

     select_x: &
            ! comment
            select case (x)
     case (1)
          print *, 'hallo'
     end select select_x

     if: &
            ! several comments
            ! several comments
            ! several comments
            if (cond) then
          x = x + 1
     end if if
end subroutine sub
```

First issue: keyword node after the block_label_start_expression was not determined correctly (&-comment*-& node sequence was not skipped). This fixes issue #160.

Second issue: alignment context node correctly is nil if point is on a comment line in between block label line and statement line (last example). However, this case was not catched and lead to an error.